### PR TITLE
デッキ保存・読み込み機能の追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,10 +14,12 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.11",
     "@vueuse/core": "^13.6.0",
+    "@vueuse/integrations": "^13.6.0",
     "html2canvas-pro": "^1.5.11",
     "neverthrow": "^8.2.0",
     "pinia": "^3.0.3",
     "tailwindcss": "^4.1.11",
+    "universal-cookie": "^7.2.2",
     "vue": "^3.5.18"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "neverthrow": "^8.2.0",
     "pinia": "^3.0.3",
     "tailwindcss": "^4.1.11",
-    "universal-cookie": "^7.2.2",
+    "universal-cookie": "^8.0.1",
     "vue": "^3.5.18"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@vueuse/core':
         specifier: ^13.6.0
         version: 13.6.0(vue@3.5.18(typescript@5.9.2))
+      '@vueuse/integrations':
+        specifier: ^13.6.0
+        version: 13.6.0(universal-cookie@7.2.2)(vue@3.5.18(typescript@5.9.2))
       html2canvas-pro:
         specifier: ^1.5.11
         version: 1.5.11
@@ -26,6 +29,9 @@ importers:
       tailwindcss:
         specifier: ^4.1.11
         version: 4.1.11
+      universal-cookie:
+        specifier: ^7.2.2
+        version: 7.2.2
       vue:
         specifier: ^3.5.18
         version: 3.5.18(typescript@5.9.2)
@@ -1124,6 +1130,9 @@ packages:
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1251,6 +1260,48 @@ packages:
     resolution: {integrity: sha512-DJbD5fV86muVmBgS9QQPddVX7d9hWYswzlf4bIyUD2dj8GC46R1uNClZhVAmsdVts4xb2jwp1PbpuiA50Qee1A==}
     peerDependencies:
       vue: ^3.5.0
+
+  '@vueuse/integrations@13.6.0':
+    resolution: {integrity: sha512-dVFdgwYvkYjdizRL3ESdUW+Hg84i9Yhuzs+Ec3kEcuzJmT5xhiL/IGdw4z394qSBngUQvFi+wbHwhHX3EGbAxQ==}
+    peerDependencies:
+      async-validator: ^4
+      axios: ^1
+      change-case: ^5
+      drauu: ^0.4
+      focus-trap: ^7
+      fuse.js: ^7
+      idb-keyval: ^6
+      jwt-decode: ^4
+      nprogress: ^0.2
+      qrcode: ^1.5
+      sortablejs: ^1
+      universal-cookie: ^7 || ^8
+      vue: ^3.5.0
+    peerDependenciesMeta:
+      async-validator:
+        optional: true
+      axios:
+        optional: true
+      change-case:
+        optional: true
+      drauu:
+        optional: true
+      focus-trap:
+        optional: true
+      fuse.js:
+        optional: true
+      idb-keyval:
+        optional: true
+      jwt-decode:
+        optional: true
+      nprogress:
+        optional: true
+      qrcode:
+        optional: true
+      sortablejs:
+        optional: true
+      universal-cookie:
+        optional: true
 
   '@vueuse/metadata@13.6.0':
     resolution: {integrity: sha512-rnIH7JvU7NjrpexTsl2Iwv0V0yAx9cw7+clymjKuLSXG0QMcLD0LDgdNmXic+qL0SGvgSVPEpM9IDO/wqo1vkQ==}
@@ -1399,6 +1450,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   copy-anything@3.0.5:
     resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
@@ -2369,6 +2424,9 @@ packages:
   unique-string@2.0.0:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
+
+  universal-cookie@7.2.2:
+    resolution: {integrity: sha512-fMiOcS3TmzP2x5QV26pIH3mvhexLIT0HmPa3V7Q7knRfT9HG6kTwq02HZGLPw0sAOXrAmotElGRvTLCMbJsvxQ==}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -3638,6 +3696,8 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
+  '@types/cookie@0.6.0': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@0.0.39': {}
@@ -3812,6 +3872,14 @@ snapshots:
       '@vueuse/shared': 13.6.0(vue@3.5.18(typescript@5.9.2))
       vue: 3.5.18(typescript@5.9.2)
 
+  '@vueuse/integrations@13.6.0(universal-cookie@7.2.2)(vue@3.5.18(typescript@5.9.2))':
+    dependencies:
+      '@vueuse/core': 13.6.0(vue@3.5.18(typescript@5.9.2))
+      '@vueuse/shared': 13.6.0(vue@3.5.18(typescript@5.9.2))
+      vue: 3.5.18(typescript@5.9.2)
+    optionalDependencies:
+      universal-cookie: 7.2.2
+
   '@vueuse/metadata@13.6.0': {}
 
   '@vueuse/shared@13.6.0(vue@3.5.18(typescript@5.9.2))':
@@ -3961,6 +4029,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@0.7.2: {}
 
   copy-anything@3.0.5:
     dependencies:
@@ -5015,6 +5085,11 @@ snapshots:
   unique-string@2.0.0:
     dependencies:
       crypto-random-string: 2.0.0
+
+  universal-cookie@7.2.2:
+    dependencies:
+      '@types/cookie': 0.6.0
+      cookie: 0.7.2
 
   universalify@2.0.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,7 +16,7 @@ importers:
         version: 13.6.0(vue@3.5.18(typescript@5.9.2))
       '@vueuse/integrations':
         specifier: ^13.6.0
-        version: 13.6.0(universal-cookie@7.2.2)(vue@3.5.18(typescript@5.9.2))
+        version: 13.6.0(universal-cookie@8.0.1)(vue@3.5.18(typescript@5.9.2))
       html2canvas-pro:
         specifier: ^1.5.11
         version: 1.5.11
@@ -30,8 +30,8 @@ importers:
         specifier: ^4.1.11
         version: 4.1.11
       universal-cookie:
-        specifier: ^7.2.2
-        version: 7.2.2
+        specifier: ^8.0.1
+        version: 8.0.1
       vue:
         specifier: ^3.5.18
         version: 3.5.18(typescript@5.9.2)
@@ -1130,9 +1130,6 @@ packages:
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
-  '@types/cookie@0.6.0':
-    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
-
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1322,10 +1319,6 @@ packages:
   alien-signals@2.0.6:
     resolution: {integrity: sha512-P3TxJSe31bUHBiblg59oU1PpaWPtmxF9GhJ/cB7OkgJ0qN/ifFSKUI25/v8ZhsT+lIG6ac8DpTOplXxORX6F3Q==}
 
-  ansi-styles@4.3.0:
-    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
-    engines: {node: '>=8'}
-
   ansis@4.1.0:
     resolution: {integrity: sha512-BGcItUBWSMRgOCe+SVZJ+S7yTRG0eGt9cXAHev72yuGcY23hnLA7Bky5L/xLyPINoSN95geovfBkqoTlNZYa7w==}
     engines: {node: '>=14'}
@@ -1419,10 +1412,6 @@ packages:
     resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
     engines: {node: '>=18'}
 
-  chalk@4.1.2:
-    resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
-    engines: {node: '>=10'}
-
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
@@ -1430,13 +1419,6 @@ packages:
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
-
-  color-convert@2.0.1:
-    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
-    engines: {node: '>=7.0.0'}
-
-  color-name@1.1.4:
-    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
   commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -1451,16 +1433,16 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie@0.7.2:
-    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
-    engines: {node: '>= 0.6'}
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
 
   copy-anything@3.0.5:
     resolution: {integrity: sha512-yCEafptTtb4bk7GLEQoM8KVJpxAfdBJYaXyzQEgQQQgYrZiDp8SJmGKlYza6CYjEDNstAdNdKA3UuoULlEbS6w==}
     engines: {node: '>=12.13'}
 
-  core-js-compat@3.44.0:
-    resolution: {integrity: sha512-JepmAj2zfl6ogy34qfWtcE7nHKAJnKsQFRn++scjVS2bZFllwptzw61BZcZFYBPpUznLfAvh0LGhxKppk04ClA==}
+  core-js-compat@3.45.0:
+    resolution: {integrity: sha512-gRoVMBawZg0OnxaVv3zpqLLxaHmsubEGyTnqdpI/CEBvX4JadI1dMSHxagThprYRtSVbuQxvi6iUatdPxohHpA==}
 
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -1525,8 +1507,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.194:
-    resolution: {integrity: sha512-SdnWJwSUot04UR51I2oPD8kuP2VI37/CADR1OHsFOUzZIvfWJBO6q11k5P/uKNyTT3cdOsnyjkrZ+DDShqYqJA==}
+  electron-to-chromium@1.5.195:
+    resolution: {integrity: sha512-URclP0iIaDUzqcAyV1v2PgduJ9N0IdXmWsnPzPfelvBmjmZzEy6xJcjb1cXj+TbYqXgtLrjHEoaSIdTYhw4ezg==}
 
   enhanced-resolve@5.18.2:
     resolution: {integrity: sha512-6Jw4sE1maoRJo3q8MsSIn2onJFbLTOjY9hlx4DZXmOKvLRd1Ok2kXmAGXaafL2+ijsJZ1ClYbl/pmqr9+k4iUQ==}
@@ -1672,10 +1654,6 @@ packages:
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
-
-  has-flag@4.0.0:
-    resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
-    engines: {node: '>=8'}
 
   has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
@@ -1831,8 +1809,8 @@ packages:
   isarray@2.0.5:
     resolution: {integrity: sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==}
 
-  jake@10.9.2:
-    resolution: {integrity: sha512-2P4SQ0HrLQ+fw6llpLnOaGAvN2Zu6778SJMrCUwns4fOoG9ayrTiZk3VV8sCPkVZF8ab0zksVpS8FDY5pRCNBA==}
+  jake@10.9.4:
+    resolution: {integrity: sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -2313,10 +2291,6 @@ packages:
     resolution: {integrity: sha512-5JRxVqC8I8NuOUjzBbvVJAKNM8qoVuH0O77h4WInc/qC2q5IreqKxYwgkga3PfA22OayK2ikceb/B26dztPl+Q==}
     engines: {node: '>=16'}
 
-  supports-color@7.2.0:
-    resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
-    engines: {node: '>=8'}
-
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -2425,8 +2399,8 @@ packages:
     resolution: {integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==}
     engines: {node: '>=8'}
 
-  universal-cookie@7.2.2:
-    resolution: {integrity: sha512-fMiOcS3TmzP2x5QV26pIH3mvhexLIT0HmPa3V7Q7knRfT9HG6kTwq02HZGLPw0sAOXrAmotElGRvTLCMbJsvxQ==}
+  universal-cookie@8.0.1:
+    resolution: {integrity: sha512-B6ks9FLLnP1UbPPcveOidfvB9pHjP+wekP2uRYB9YDfKVpvcjKgy1W5Zj+cEXJ9KTPnqOKGfVDQBmn8/YCQfRg==}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -3264,7 +3238,7 @@ snapshots:
       babel-plugin-polyfill-corejs2: 0.4.14(@babel/core@7.28.0)
       babel-plugin-polyfill-corejs3: 0.13.0(@babel/core@7.28.0)
       babel-plugin-polyfill-regenerator: 0.6.5(@babel/core@7.28.0)
-      core-js-compat: 3.44.0
+      core-js-compat: 3.45.0
       semver: 6.3.1
     transitivePeerDependencies:
       - supports-color
@@ -3696,8 +3670,6 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
 
-  '@types/cookie@0.6.0': {}
-
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@0.0.39': {}
@@ -3872,13 +3844,13 @@ snapshots:
       '@vueuse/shared': 13.6.0(vue@3.5.18(typescript@5.9.2))
       vue: 3.5.18(typescript@5.9.2)
 
-  '@vueuse/integrations@13.6.0(universal-cookie@7.2.2)(vue@3.5.18(typescript@5.9.2))':
+  '@vueuse/integrations@13.6.0(universal-cookie@8.0.1)(vue@3.5.18(typescript@5.9.2))':
     dependencies:
       '@vueuse/core': 13.6.0(vue@3.5.18(typescript@5.9.2))
       '@vueuse/shared': 13.6.0(vue@3.5.18(typescript@5.9.2))
       vue: 3.5.18(typescript@5.9.2)
     optionalDependencies:
-      universal-cookie: 7.2.2
+      universal-cookie: 8.0.1
 
   '@vueuse/metadata@13.6.0': {}
 
@@ -3896,10 +3868,6 @@ snapshots:
       require-from-string: 2.0.2
 
   alien-signals@2.0.6: {}
-
-  ansi-styles@4.3.0:
-    dependencies:
-      color-convert: 2.0.1
 
   ansis@4.1.0: {}
 
@@ -3943,7 +3911,7 @@ snapshots:
     dependencies:
       '@babel/core': 7.28.0
       '@babel/helper-define-polyfill-provider': 0.6.5(@babel/core@7.28.0)
-      core-js-compat: 3.44.0
+      core-js-compat: 3.45.0
     transitivePeerDependencies:
       - supports-color
 
@@ -3972,7 +3940,7 @@ snapshots:
   browserslist@4.25.1:
     dependencies:
       caniuse-lite: 1.0.30001731
-      electron-to-chromium: 1.5.194
+      electron-to-chromium: 1.5.195
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
 
@@ -4007,20 +3975,9 @@ snapshots:
       loupe: 3.2.0
       pathval: 2.0.1
 
-  chalk@4.1.2:
-    dependencies:
-      ansi-styles: 4.3.0
-      supports-color: 7.2.0
-
   check-error@2.1.1: {}
 
   chownr@3.0.0: {}
-
-  color-convert@2.0.1:
-    dependencies:
-      color-name: 1.1.4
-
-  color-name@1.1.4: {}
 
   commander@2.20.3: {}
 
@@ -4030,13 +3987,13 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie@0.7.2: {}
+  cookie@1.0.2: {}
 
   copy-anything@3.0.5:
     dependencies:
       is-what: 4.1.16
 
-  core-js-compat@3.44.0:
+  core-js-compat@3.45.0:
     dependencies:
       browserslist: 4.25.1
 
@@ -4098,9 +4055,9 @@ snapshots:
 
   ejs@3.1.10:
     dependencies:
-      jake: 10.9.2
+      jake: 10.9.4
 
-  electron-to-chromium@1.5.194: {}
+  electron-to-chromium@1.5.195: {}
 
   enhanced-resolve@5.18.2:
     dependencies:
@@ -4323,8 +4280,6 @@ snapshots:
 
   has-bigints@1.1.0: {}
 
-  has-flag@4.0.0: {}
-
   has-property-descriptors@1.0.2:
     dependencies:
       es-define-property: 1.0.1
@@ -4478,12 +4433,11 @@ snapshots:
 
   isarray@2.0.5: {}
 
-  jake@10.9.2:
+  jake@10.9.4:
     dependencies:
       async: 3.2.6
-      chalk: 4.1.2
       filelist: 1.0.4
-      minimatch: 3.1.2
+      picocolors: 1.1.1
 
   jiti@2.5.1: {}
 
@@ -4966,10 +4920,6 @@ snapshots:
     dependencies:
       copy-anything: 3.0.5
 
-  supports-color@7.2.0:
-    dependencies:
-      has-flag: 4.0.0
-
   supports-preserve-symlinks-flag@1.0.0: {}
 
   tailwindcss@4.1.11: {}
@@ -5086,10 +5036,9 @@ snapshots:
     dependencies:
       crypto-random-string: 2.0.0
 
-  universal-cookie@7.2.2:
+  universal-cookie@8.0.1:
     dependencies:
-      '@types/cookie': 0.6.0
-      cookie: 0.7.2
+      cookie: 1.0.2
 
   universalify@2.0.1: {}
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -17,13 +17,20 @@ import {
   DeckCodeModal,
   FilterModal,
   CardImageModal,
+  DeckManagementModal,
 } from "./components";
 import type { Card, DeckCard } from "./types";
 import { getCardImageUrlSafe, safeSyncOperation } from "./utils";
 
 // ストア初期化
 const appStore = useAppStore();
-const { cardsStore, deckStore, filterStore, deckCodeStore } = appStore;
+const {
+  cardsStore,
+  deckStore,
+  filterStore,
+  deckCodeStore,
+  deckManagementStore,
+} = appStore;
 
 // Vue 3.5の新機能: useTemplateRef でテンプレート参照を管理
 const deckSectionRef =
@@ -218,6 +225,9 @@ const shouldShowResetConfirmModal = computed(
   () => appStore.showResetConfirmModal,
 );
 const shouldShowImageModal = computed(() => imageModalState.value.isVisible);
+const shouldShowDeckManagementModal = computed(
+  () => deckManagementStore.isDeckManagementModalOpen,
+);
 
 // デッキセクションのプロパティを計算（Vue 3.5の最適化されたcomputed）
 const deckSectionProps = computed(() => ({
@@ -268,6 +278,9 @@ const cardImageModalProps = computed(() => ({
         @generate-deck-code="deckCodeStore.generateAndShowDeckCode"
         @reset-deck="appStore.resetDeck"
         @open-image-modal="openImageModal"
+        @open-deck-management-modal="
+          deckManagementStore.openDeckManagementModal
+        "
         class="lg:w-1/2 lg:h-full overflow-y-auto"
       />
 
@@ -318,6 +331,9 @@ const cardImageModalProps = computed(() => ({
       @close="closeImageModal"
       @navigate="handleCardNavigation"
     />
+
+    <!-- デッキ管理モーダル -->
+    <DeckManagementModal v-if="shouldShowDeckManagementModal" />
   </div>
 </template>
 

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -5,3 +5,4 @@ export { default as CardImageModal } from "./modals/CardImageModal.vue";
 export { default as ConfirmModal } from "./modals/ConfirmModal.vue";
 export { default as DeckCodeModal } from "./modals/DeckCodeModal.vue";
 export { default as FilterModal } from "./modals/FilterModal.vue";
+export { default as DeckManagementModal } from "./modals/DeckManagementModal.vue";

--- a/src/components/layout/CardListSection.vue
+++ b/src/components/layout/CardListSection.vue
@@ -181,16 +181,13 @@ watchEffect((onCleanup) => {
         class="text-sm sm:text-base font-bold text-slate-100 flex items-center gap-1"
       >
         <svg
-          class="w-4 h-4 text-blue-400"
-          fill="none"
+          class="w-4 h-4"
+          fill="oklch(70.7% 0.165 254.624)"
           stroke="currentColor"
-          viewBox="0 0 24 24"
+          viewBox="0 -960 960 960"
         >
           <path
-            stroke-linecap="round"
-            stroke-linejoin="round"
-            stroke-width="2"
-            d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10"
+            d="M120-520v-320h320v320H120Zm0 400v-320h320v320H120Zm400-400v-320h320v320H520Zm0 400v-320h320v320H520ZM200-600h160v-160H200v160Zm400 0h160v-160H600v160Zm0 400h160v-160H600v160Zm-400 0h160v-160H200v160Zm400-400Zm0 240Zm-240 0Zm0-240Z"
           ></path>
         </svg>
         カード一覧
@@ -203,15 +200,12 @@ watchEffect((onCleanup) => {
         <span class="flex items-center gap-1">
           <svg
             class="w-3 h-3"
-            fill="none"
+            fill="white"
             stroke="currentColor"
-            viewBox="0 0 24 24"
+            viewBox="0 -960 960 960"
           >
             <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M3 4a1 1 0 011-1h16a1 1 0 011 1v2.586a1 1 0 01-.293.707l-6.414 6.414a1 1 0 00-.293.707V17l-4 4v-6.586a1 1 0 00-.293-.707L3.293 7.414A1 1 0 013 6.586V4z"
+              d="M784-120 532-372q-30 24-69 38t-83 14q-109 0-184.5-75.5T120-580q0-109 75.5-184.5T380-840q109 0 184.5 75.5T640-580q0 44-14 83t-38 69l252 252-56 56ZM380-400q75 0 127.5-52.5T560-580q0-75-52.5-127.5T380-760q-75 0-127.5 52.5T200-580q0 75 52.5 127.5T380-400Z"
             ></path>
           </svg>
           <span class="hidden sm:inline">検索/絞り込み</span>

--- a/src/components/layout/DeckSection.vue
+++ b/src/components/layout/DeckSection.vue
@@ -5,7 +5,6 @@ import { handleImageError } from "../../utils/image";
 import { getCardImageUrlSafe } from "../../utils";
 import { useDeckOperations } from "../../composables/useDeckOperations";
 import { useDeckStore } from "../../stores/deck";
-import { useExportStore } from "../../stores/export";
 import { onLongPress } from "@vueuse/core";
 
 // Vue 3.5の新機能: 改善されたdefineProps with better TypeScript support
@@ -19,6 +18,7 @@ interface Emits {
   (e: "generateDeckCode"): void;
   (e: "resetDeck"): void;
   (e: "openImageModal", cardId: string): void;
+  (e: "openDeckManagementModal"): void;
 }
 
 const props = defineProps<Props>();
@@ -26,7 +26,6 @@ const emit = defineEmits<Emits>();
 
 // ストアとコンポーザブルの初期化
 const deckStore = useDeckStore();
-const exportStore = useExportStore();
 
 // デッキ操作のコンポーザブル
 const {
@@ -112,24 +111,11 @@ const getDeckProgressColor = (count: number) => {
   return "bg-blue-500";
 };
 
-// デッキ画像保存処理
-const saveDeckAsPng = async () => {
-  const container = exportContainer.value;
-  if (container) {
-    try {
-      await exportStore.saveDeckAsPng(deckName.value, container);
-    } catch (error) {
-      console.error("デッキ画像の保存中にエラーが発生しました:", error);
-    }
-  }
-};
-
 // エクスポート用
 defineExpose({
   exportContainer,
   decrementCard,
   resetDeck,
-  saveDeckAsPng,
   updateDeckName,
 });
 </script>
@@ -171,15 +157,12 @@ defineExpose({
         >
           <svg
             class="w-3 h-3"
-            fill="none"
+            fill="white"
             stroke="currentColor"
-            viewBox="0 0 24 24"
+            viewBox="0 -960 960 960"
           >
             <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+              d="M360-240q-33 0-56.5-23.5T280-320v-480q0-33 23.5-56.5T360-880h360q33 0 56.5 23.5T800-800v480q0 33-23.5 56.5T720-240H360Zm0-80h360v-480H360v480ZM200-80q-33 0-56.5-23.5T120-160v-560h80v560h440v80H200Zm160-240v-480 480Z"
             ></path>
           </svg>
           <span class="hidden sm:inline">デッキコード</span>
@@ -206,48 +189,23 @@ defineExpose({
       </button>
 
       <button
-        @click="saveDeckAsPng"
-        :disabled="deckCards.length === 0 || props.isSaving"
+        @click="emit('openDeckManagementModal')"
         class="group relative flex-1 min-w-0 px-1 sm:px-2 py-0.5 sm:py-1 bg-gradient-to-r from-emerald-600 to-emerald-700 text-white rounded text-xs font-medium hover:from-emerald-700 hover:to-emerald-800 disabled:from-slate-600 disabled:to-slate-700 disabled:cursor-not-allowed transition-all duration-200 shadow-lg hover:shadow-emerald-500/25"
-        title="デッキ画像を保存"
+        title="デッキの保存・読み込み"
       >
-        <span
-          v-if="!props.isSaving"
-          class="flex items-center justify-center gap-1"
-        >
+        <span class="flex items-center justify-center gap-1">
           <svg
             class="w-3 h-3"
-            fill="none"
+            fill="white"
             stroke="currentColor"
-            viewBox="0 0 24 24"
+            viewBox="0 -960 960 960"
           >
             <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+              d="M840-680v480q0 33-23.5 56.5T760-120H200q-33 0-56.5-23.5T120-200v-560q0-33 23.5-56.5T200-840h480l160 160Zm-80 34L646-760H200v560h560v-446ZM480-240q50 0 85-35t35-85q0-50-35-85t-85-35q-50 0-85 35t-35 85q0 50 35 85t85 35ZM240-560h360v-160H240v160Zm-40-86v446-560 114Z"
             ></path>
           </svg>
-          <span class="hidden sm:inline">デッキ画像保存</span>
-          <span class="sm:hidden">画像保存</span>
-        </span>
-        <span v-else class="flex items-center justify-center gap-1">
-          <svg class="w-3 h-3 animate-spin" fill="none" viewBox="0 0 24 24">
-            <circle
-              class="opacity-25"
-              cx="12"
-              cy="12"
-              r="10"
-              stroke="currentColor"
-              stroke-width="4"
-            ></circle>
-            <path
-              class="opacity-75"
-              fill="currentColor"
-              d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-            ></path>
-          </svg>
-          保存中...
+          <span class="hidden sm:inline">デッキ保存</span>
+          <span class="sm:hidden">保存</span>
         </span>
       </button>
 
@@ -260,15 +218,12 @@ defineExpose({
         <span class="flex items-center justify-center gap-1">
           <svg
             class="w-3 h-3"
-            fill="none"
+            fill="white"
             stroke="currentColor"
-            viewBox="0 0 24 24"
+            viewBox="0 -960 960 960"
           >
             <path
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="2"
-              d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"
+              d="M280-120q-33 0-56.5-23.5T200-200v-520h-40v-80h200v-40h240v40h200v80h-40v520q0 33-23.5 56.5T680-120H280Zm400-600H280v520h400v-520ZM360-280h80v-360h-80v360Zm160 0h80v-360h-80v360ZM280-720v520-520Z"
             ></path>
           </svg>
           <span class="hidden sm:inline">リセット</span>

--- a/src/components/modals/DeckManagementModal.vue
+++ b/src/components/modals/DeckManagementModal.vue
@@ -1,0 +1,177 @@
+<script setup lang="ts">
+import { ref, computed } from "vue";
+import { useDeckManagementStore } from "../../stores/deckManagement";
+import { useDeckStore } from "../../stores/deck";
+import { useDeckCodeStore } from "../../stores/deckCode";
+import { useAppStore } from "../../stores/app";
+
+const deckManagementStore = useDeckManagementStore();
+const deckStore = useDeckStore();
+const deckCodeStore = useDeckCodeStore();
+const appStore = useAppStore();
+
+const newDeckName = ref(deckStore.deckName);
+
+const isSaveMode = ref(true); // true: 保存モード, false: 読み込みモード
+
+const currentDeckName = computed(() => deckStore.deckName);
+const currentDeckCode = computed(() => deckCodeStore.kcgDeckCode);
+
+const saveDeck = () => {
+  if (newDeckName.value && currentDeckCode.value) {
+    deckManagementStore.saveDeck(newDeckName.value, currentDeckCode.value);
+    newDeckName.value = ""; // 保存後に入力欄をクリア
+  }
+};
+
+const loadDeck = (deckName: string, deckCode: string) => {
+  deckStore.setDeckName(deckName);
+  deckCodeStore.setImportDeckCode(deckCode);
+  appStore.importDeckFromCode();
+  deckManagementStore.closeDeckManagementModal();
+};
+
+const deleteDeck = (deckName: string) => {
+  if (confirm(`デッキ「${deckName}」を削除してもよろしいですか？`)) {
+    deckManagementStore.deleteDeck(deckName);
+  }
+};
+
+const saveDeckAsPng = async () => {
+  if (appStore.deckSectionRef?.exportContainer) {
+    appStore.exportStore.saveDeckAsPng(
+      deckStore.deckName,
+      appStore.deckSectionRef.exportContainer,
+    );
+    deckManagementStore.closeDeckManagementModal();
+  }
+};
+
+const closeModal = () => {
+  deckManagementStore.closeDeckManagementModal();
+};
+</script>
+
+<template>
+  <div
+    v-if="deckManagementStore.isDeckManagementModalOpen"
+    class="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center z-50 p-4"
+    @click.self="closeModal"
+  >
+    <div
+      class="bg-slate-800 rounded-lg shadow-xl p-6 w-full max-w-md border border-slate-700 relative"
+    >
+      <button
+        @click="closeModal"
+        class="absolute top-3 right-3 text-slate-400 hover:text-slate-200 transition-colors"
+      >
+        <svg
+          class="w-6 h-6"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M6 18L18 6M6 6l12 12"
+          ></path>
+        </svg>
+      </button>
+
+      <h2 class="text-2xl font-bold text-white mb-4">デッキ管理</h2>
+
+      <div class="flex mb-4">
+        <button
+          @click="isSaveMode = true"
+          :class="{ 'bg-blue-600': isSaveMode, 'bg-slate-700': !isSaveMode }"
+          class="flex-1 py-2 rounded-l-lg text-white font-medium transition-colors"
+        >
+          デッキ保存
+        </button>
+        <button
+          @click="isSaveMode = false"
+          :class="{ 'bg-blue-600': !isSaveMode, 'bg-slate-700': isSaveMode }"
+          class="flex-1 py-2 rounded-r-lg text-white font-medium transition-colors"
+        >
+          デッキ読み込み・削除
+        </button>
+      </div>
+
+      <div v-if="isSaveMode">
+        <div class="mb-4">
+          <label
+            for="deckNameInput"
+            class="block text-slate-300 text-sm font-bold mb-2"
+            >現在のデッキ名:</label
+          >
+          <input
+            id="deckNameInput"
+            type="text"
+            v-model="newDeckName"
+            :placeholder="currentDeckName || 'デッキ名を入力'"
+            class="shadow appearance-none border border-slate-600 rounded w-full py-2 px-3 text-slate-200 leading-tight focus:outline-none focus:shadow-outline bg-slate-700"
+          />
+        </div>
+        <div class="mb-4">
+          <label class="block text-slate-300 text-sm font-bold mb-2"
+            >現在のデッキコード:</label
+          >
+          <textarea
+            :value="currentDeckCode"
+            readonly
+            class="shadow appearance-none border border-slate-600 rounded w-full py-2 px-3 text-slate-200 leading-tight focus:outline-none focus:shadow-outline bg-slate-700 h-24 resize-none"
+          ></textarea>
+        </div>
+        <button
+          @click="saveDeck"
+          :disabled="!newDeckName || !currentDeckCode"
+          class="bg-green-600 hover:bg-green-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline w-full disabled:opacity-50 disabled:cursor-not-allowed"
+        >
+          保存
+        </button>
+        <button
+          @click="saveDeckAsPng"
+          class="mt-2 bg-emerald-600 hover:bg-emerald-700 text-white font-bold py-2 px-4 rounded focus:outline-none focus:shadow-outline w-full"
+        >
+          デッキ画像を保存
+        </button>
+      </div>
+
+      <div v-else>
+        <div v-if="deckManagementStore.savedDecks.length > 0">
+          <ul
+            class="max-h-60 overflow-y-auto mb-4 border border-slate-700 rounded"
+          >
+            <li
+              v-for="deck in deckManagementStore.savedDecks"
+              :key="deck.name"
+              class="flex justify-between items-center p-3 border-b border-slate-700 last:border-b-0 hover:bg-slate-700 transition-colors"
+            >
+              <span class="text-slate-200 font-medium">{{ deck.name }}</span>
+              <div class="flex space-x-2">
+                <button
+                  @click="loadDeck(deck.name, deck.code)"
+                  class="bg-blue-600 hover:bg-blue-700 text-white text-xs font-bold py-1 px-2 rounded focus:outline-none focus:shadow-outline"
+                >
+                  読み込み
+                </button>
+                <button
+                  @click="deleteDeck(deck.name)"
+                  class="bg-red-600 hover:bg-red-700 text-white text-xs font-bold py-1 px-2 rounded focus:outline-none focus:shadow-outline"
+                >
+                  削除
+                </button>
+              </div>
+            </li>
+          </ul>
+        </div>
+        <div v-else class="text-center text-slate-400 py-8">
+          保存されたデッキはありません。
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/src/stores/app.ts
+++ b/src/stores/app.ts
@@ -6,6 +6,7 @@ import { useFilterStore } from "./filter";
 
 import { useDeckCodeStore } from "./deckCode";
 import { useExportStore } from "./export";
+import { useDeckManagementStore } from "./deckManagement";
 
 import type DeckSection from "../components/layout/DeckSection.vue";
 
@@ -29,8 +30,16 @@ export const useAppStore = defineStore("app", () => {
     const filterStore = useFilterStore();
     const deckCodeStore = useDeckCodeStore();
     const exportStore = useExportStore();
+    const deckManagementStore = useDeckManagementStore();
 
-    return { cardsStore, deckStore, filterStore, deckCodeStore, exportStore };
+    return {
+      cardsStore,
+      deckStore,
+      filterStore,
+      deckCodeStore,
+      exportStore,
+      deckManagementStore,
+    };
   };
 
   // 各ストアのインスタンス取得（遅延初期化）
@@ -68,6 +77,7 @@ export const useAppStore = defineStore("app", () => {
     try {
       await stores.cardsStore.loadCards();
       stores.deckStore.initializeDeck(stores.cardsStore.availableCards);
+      stores.deckCodeStore.generateDeckCodes();
     } catch (error) {
       console.error("Application initialization failed:", error);
       throw error;

--- a/src/stores/deckCode.ts
+++ b/src/stores/deckCode.ts
@@ -25,9 +25,9 @@ export const useDeckCodeStore = defineStore("deckCode", () => {
   const deckStore = useDeckStore();
 
   /**
-   * デッキコードを生成・表示
+   * デッキコードを生成
    */
-  const generateAndShowDeckCode = (): void => {
+  const generateDeckCodes = (): void => {
     isGeneratingCode.value = true;
     error.value = null;
     try {
@@ -65,7 +65,6 @@ export const useDeckCodeStore = defineStore("deckCode", () => {
           sortedDeck.map((item: DeckCard) => `${item.card.id} x${item.count}`),
         );
       }
-      showDeckCodeModal.value = true;
     } catch (e) {
       const errorMessage = "デッキコードの生成に失敗しました";
       logger.error(errorMessage + ":", e);
@@ -73,6 +72,14 @@ export const useDeckCodeStore = defineStore("deckCode", () => {
     } finally {
       isGeneratingCode.value = false;
     }
+  };
+
+  /**
+   * デッキコードを生成し、モーダルを表示
+   */
+  const generateAndShowDeckCode = (): void => {
+    generateDeckCodes();
+    showDeckCodeModal.value = true;
   };
 
   /**
@@ -366,6 +373,7 @@ export const useDeckCodeStore = defineStore("deckCode", () => {
     isGeneratingCode,
     showDeckCodeModal,
     error,
+    generateDeckCodes,
     generateAndShowDeckCode,
     copyDeckCode,
     importDeckFromCode,

--- a/src/stores/deckManagement.ts
+++ b/src/stores/deckManagement.ts
@@ -1,0 +1,78 @@
+import { defineStore } from "pinia";
+import { ref } from "vue";
+import { useCookies } from "@vueuse/integrations/useCookies";
+import { useDeckCodeStore } from "./deckCode";
+
+interface SavedDeck {
+  name: string;
+  code: string;
+}
+
+export const useDeckManagementStore = defineStore("deckManagement", () => {
+  const cookies = useCookies(["savedDecks"]);
+  const isDeckManagementModalOpen = ref(false);
+  const savedDecks = ref<SavedDeck[]>([]);
+  const deckCodeStore = useDeckCodeStore();
+
+  // 初期化時にCookieからデッキを読み込む
+  const loadDecksFromCookie = () => {
+    const storedDecks = cookies.get("savedDecks");
+    if (storedDecks && Array.isArray(storedDecks)) {
+      savedDecks.value = storedDecks;
+    } else {
+      savedDecks.value = [];
+    }
+  };
+
+  // デッキをCookieに保存する
+  const saveDecksToCookie = () => {
+    cookies.set("savedDecks", savedDecks.value, {
+      expires: new Date(Date.now() + 365 * 24 * 60 * 60 * 1000),
+    }); // 1年間有効
+  };
+
+  // デッキを保存する
+  const saveDeck = (deckName: string, deckCode: string) => {
+    const existingIndex = savedDecks.value.findIndex(
+      (deck) => deck.name === deckName,
+    );
+    if (existingIndex !== -1) {
+      // 既存のデッキを更新
+      savedDecks.value[existingIndex] = { name: deckName, code: deckCode };
+    } else {
+      // 新しいデッキを追加
+      savedDecks.value.push({ name: deckName, code: deckCode });
+    }
+    saveDecksToCookie();
+  };
+
+  // デッキを削除する
+  const deleteDeck = (deckName: string) => {
+    savedDecks.value = savedDecks.value.filter(
+      (deck) => deck.name !== deckName,
+    );
+    saveDecksToCookie();
+  };
+
+  // デッキ管理モーダルを開く
+  const openDeckManagementModal = () => {
+    loadDecksFromCookie(); // モーダルを開く際に最新のデッキリストを読み込む
+    deckCodeStore.generateDeckCodes(); // デッキコードを更新
+    isDeckManagementModalOpen.value = true;
+  };
+
+  // デッキ管理モーダルを閉じる
+  const closeDeckManagementModal = () => {
+    isDeckManagementModalOpen.value = false;
+  };
+
+  return {
+    isDeckManagementModalOpen,
+    savedDecks,
+    saveDeck,
+    deleteDeck,
+    openDeckManagementModal,
+    closeDeckManagementModal,
+    loadDecksFromCookie,
+  };
+});

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -4,3 +4,4 @@ export { useFilterStore } from "./filter";
 export { useDeckCodeStore } from "./deckCode";
 export { useExportStore } from "./export";
 export { useAppStore } from "./app";
+export { useDeckManagementStore } from "./deckManagement";


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * デッキの保存・読み込み・削除ができる「デッキ管理モーダル」を追加しました。
  * デッキ管理はブラウザのクッキーに保存され、次回以降も利用可能です。
  * デッキ名とデッキコードでの管理や、保存済みデッキの一覧表示・削除が可能です。
  * デッキのエクスポート（PNG画像として保存）機能をモーダル内に移動しました。

* **改善**
  * デッキセクションやカードリストのボタンアイコンを刷新し、視認性を向上しました。
  * アプリ起動時にデッキコードを自動生成する処理を追加しました。

* **内部処理**
  * デッキコード生成処理を分割・整理し、モーダル表示との連携を改善しました。
  * デッキ管理用の状態管理ストアを新設し、モーダルの開閉やデッキデータの永続化を実装しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->