### PR TITLE
スワイプでカード送りできないことの修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.1.12",
-    "@vueuse/core": "^13.7.0",
-    "@vueuse/integrations": "^13.7.0",
+    "@vueuse/core": "^13.8.0",
+    "@vueuse/integrations": "^13.8.0",
     "html2canvas-pro": "^1.5.11",
     "neverthrow": "^8.2.0",
     "papaparse": "^5.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1688,8 +1688,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.210:
-    resolution: {integrity: sha512-20kSVv1tyNBN2VFsjCIJZfyvxqo7ylHPrJLME040f/030lzNMA7uQNpxtqJjWSNpccD8/2sqe53EAjrFPvQmjw==}
+  electron-to-chromium@1.5.211:
+    resolution: {integrity: sha512-IGBvimJkotaLzFnwIVgW9/UD/AOJ2tByUmeOrtqBfACSbAw5b1G0XpvdaieKyc7ULmbwXVx+4e4Be8pOPBrYkw==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -4387,7 +4387,7 @@ snapshots:
   browserslist@4.25.3:
     dependencies:
       caniuse-lite: 1.0.30001737
-      electron-to-chromium: 1.5.210
+      electron-to-chromium: 1.5.211
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.3)
 
@@ -4518,7 +4518,7 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-to-chromium@1.5.210: {}
+  electron-to-chromium@1.5.211: {}
 
   emoji-regex@8.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,11 +12,11 @@ importers:
         specifier: ^4.1.12
         version: 4.1.12(rolldown-vite@7.1.5(@types/node@24.3.0)(esbuild@0.25.9)(jiti@2.5.1)(terser@5.43.1))
       '@vueuse/core':
-        specifier: ^13.7.0
-        version: 13.7.0(vue@3.5.20(typescript@5.9.2))
+        specifier: ^13.8.0
+        version: 13.8.0(vue@3.5.20(typescript@5.9.2))
       '@vueuse/integrations':
-        specifier: ^13.7.0
-        version: 13.7.0(universal-cookie@8.0.1)(vue@3.5.20(typescript@5.9.2))
+        specifier: ^13.8.0
+        version: 13.8.0(universal-cookie@8.0.1)(vue@3.5.20(typescript@5.9.2))
       html2canvas-pro:
         specifier: ^1.5.11
         version: 1.5.11
@@ -1064,103 +1064,103 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.48.1':
-    resolution: {integrity: sha512-rGmb8qoG/zdmKoYELCBwu7vt+9HxZ7Koos3pD0+sH5fR3u3Wb/jGcpnqxcnWsPEKDUyzeLSqksN8LJtgXjqBYw==}
+  '@rollup/rollup-android-arm-eabi@4.49.0':
+    resolution: {integrity: sha512-rlKIeL854Ed0e09QGYFlmDNbka6I3EQFw7iZuugQjMb11KMpJCLPFL4ZPbMfaEhLADEL1yx0oujGkBQ7+qW3eA==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.48.1':
-    resolution: {integrity: sha512-4e9WtTxrk3gu1DFE+imNJr4WsL13nWbD/Y6wQcyku5qadlKHY3OQ3LJ/INrrjngv2BJIHnIzbqMk1GTAC2P8yQ==}
+  '@rollup/rollup-android-arm64@4.49.0':
+    resolution: {integrity: sha512-cqPpZdKUSQYRtLLr6R4X3sD4jCBO1zUmeo3qrWBCqYIeH8Q3KRL4F3V7XJ2Rm8/RJOQBZuqzQGWPjjvFUcYa/w==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.48.1':
-    resolution: {integrity: sha512-+XjmyChHfc4TSs6WUQGmVf7Hkg8ferMAE2aNYYWjiLzAS/T62uOsdfnqv+GHRjq7rKRnYh4mwWb4Hz7h/alp8A==}
+  '@rollup/rollup-darwin-arm64@4.49.0':
+    resolution: {integrity: sha512-99kMMSMQT7got6iYX3yyIiJfFndpojBmkHfTc1rIje8VbjhmqBXE+nb7ZZP3A5skLyujvT0eIUCUsxAe6NjWbw==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.48.1':
-    resolution: {integrity: sha512-upGEY7Ftw8M6BAJyGwnwMw91rSqXTcOKZnnveKrVWsMTF8/k5mleKSuh7D4v4IV1pLxKAk3Tbs0Lo9qYmii5mQ==}
+  '@rollup/rollup-darwin-x64@4.49.0':
+    resolution: {integrity: sha512-y8cXoD3wdWUDpjOLMKLx6l+NFz3NlkWKcBCBfttUn+VGSfgsQ5o/yDUGtzE9HvsodkP0+16N0P4Ty1VuhtRUGg==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.48.1':
-    resolution: {integrity: sha512-P9ViWakdoynYFUOZhqq97vBrhuvRLAbN/p2tAVJvhLb8SvN7rbBnJQcBu8e/rQts42pXGLVhfsAP0k9KXWa3nQ==}
+  '@rollup/rollup-freebsd-arm64@4.49.0':
+    resolution: {integrity: sha512-3mY5Pr7qv4GS4ZvWoSP8zha8YoiqrU+e0ViPvB549jvliBbdNLrg2ywPGkgLC3cmvN8ya3za+Q2xVyT6z+vZqA==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.48.1':
-    resolution: {integrity: sha512-VLKIwIpnBya5/saccM8JshpbxfyJt0Dsli0PjXozHwbSVaHTvWXJH1bbCwPXxnMzU4zVEfgD1HpW3VQHomi2AQ==}
+  '@rollup/rollup-freebsd-x64@4.49.0':
+    resolution: {integrity: sha512-C9KzzOAQU5gU4kG8DTk+tjdKjpWhVWd5uVkinCwwFub2m7cDYLOdtXoMrExfeBmeRy9kBQMkiyJ+HULyF1yj9w==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.48.1':
-    resolution: {integrity: sha512-3zEuZsXfKaw8n/yF7t8N6NNdhyFw3s8xJTqjbTDXlipwrEHo4GtIKcMJr5Ed29leLpB9AugtAQpAHW0jvtKKaQ==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.49.0':
+    resolution: {integrity: sha512-OVSQgEZDVLnTbMq5NBs6xkmz3AADByCWI4RdKSFNlDsYXdFtlxS59J+w+LippJe8KcmeSSM3ba+GlsM9+WwC1w==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.48.1':
-    resolution: {integrity: sha512-leo9tOIlKrcBmmEypzunV/2w946JeLbTdDlwEZ7OnnsUyelZ72NMnT4B2vsikSgwQifjnJUbdXzuW4ToN1wV+Q==}
+  '@rollup/rollup-linux-arm-musleabihf@4.49.0':
+    resolution: {integrity: sha512-ZnfSFA7fDUHNa4P3VwAcfaBLakCbYaxCk0jUnS3dTou9P95kwoOLAMlT3WmEJDBCSrOEFFV0Y1HXiwfLYJuLlA==}
     cpu: [arm]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-gnu@4.48.1':
-    resolution: {integrity: sha512-Vy/WS4z4jEyvnJm+CnPfExIv5sSKqZrUr98h03hpAMbE2aI0aD2wvK6GiSe8Gx2wGp3eD81cYDpLLBqNb2ydwQ==}
+  '@rollup/rollup-linux-arm64-gnu@4.49.0':
+    resolution: {integrity: sha512-Z81u+gfrobVK2iV7GqZCBfEB1y6+I61AH466lNK+xy1jfqFLiQ9Qv716WUM5fxFrYxwC7ziVdZRU9qvGHkYIJg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-arm64-musl@4.48.1':
-    resolution: {integrity: sha512-x5Kzn7XTwIssU9UYqWDB9VpLpfHYuXw5c6bJr4Mzv9kIv242vmJHbI5PJJEnmBYitUIfoMCODDhR7KoZLot2VQ==}
+  '@rollup/rollup-linux-arm64-musl@4.49.0':
+    resolution: {integrity: sha512-zoAwS0KCXSnTp9NH/h9aamBAIve0DXeYpll85shf9NJ0URjSTzzS+Z9evmolN+ICfD3v8skKUPyk2PO0uGdFqg==}
     cpu: [arm64]
     os: [linux]
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.48.1':
-    resolution: {integrity: sha512-yzCaBbwkkWt/EcgJOKDUdUpMHjhiZT/eDktOPWvSRpqrVE04p0Nd6EGV4/g7MARXXeOqstflqsKuXVM3H9wOIQ==}
+  '@rollup/rollup-linux-loongarch64-gnu@4.49.0':
+    resolution: {integrity: sha512-2QyUyQQ1ZtwZGiq0nvODL+vLJBtciItC3/5cYN8ncDQcv5avrt2MbKt1XU/vFAJlLta5KujqyHdYtdag4YEjYQ==}
     cpu: [loong64]
     os: [linux]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.48.1':
-    resolution: {integrity: sha512-UK0WzWUjMAJccHIeOpPhPcKBqax7QFg47hwZTp6kiMhQHeOYJeaMwzeRZe1q5IiTKsaLnHu9s6toSYVUlZ2QtQ==}
+  '@rollup/rollup-linux-ppc64-gnu@4.49.0':
+    resolution: {integrity: sha512-k9aEmOWt+mrMuD3skjVJSSxHckJp+SiFzFG+v8JLXbc/xi9hv2icSkR3U7uQzqy+/QbbYY7iNB9eDTwrELo14g==}
     cpu: [ppc64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.48.1':
-    resolution: {integrity: sha512-3NADEIlt+aCdCbWVZ7D3tBjBX1lHpXxcvrLt/kdXTiBrOds8APTdtk2yRL2GgmnSVeX4YS1JIf0imFujg78vpw==}
+  '@rollup/rollup-linux-riscv64-gnu@4.49.0':
+    resolution: {integrity: sha512-rDKRFFIWJ/zJn6uk2IdYLc09Z7zkE5IFIOWqpuU0o6ZpHcdniAyWkwSUWE/Z25N/wNDmFHHMzin84qW7Wzkjsw==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-riscv64-musl@4.48.1':
-    resolution: {integrity: sha512-euuwm/QTXAMOcyiFCcrx0/S2jGvFlKJ2Iro8rsmYL53dlblp3LkUQVFzEidHhvIPPvcIsxDhl2wkBE+I6YVGzA==}
+  '@rollup/rollup-linux-riscv64-musl@4.49.0':
+    resolution: {integrity: sha512-FkkhIY/hYFVnOzz1WeV3S9Bd1h0hda/gRqvZCMpHWDHdiIHn6pqsY3b5eSbvGccWHMQ1uUzgZTKS4oGpykf8Tw==}
     cpu: [riscv64]
     os: [linux]
 
-  '@rollup/rollup-linux-s390x-gnu@4.48.1':
-    resolution: {integrity: sha512-w8mULUjmPdWLJgmTYJx/W6Qhln1a+yqvgwmGXcQl2vFBkWsKGUBRbtLRuKJUln8Uaimf07zgJNxOhHOvjSQmBQ==}
+  '@rollup/rollup-linux-s390x-gnu@4.49.0':
+    resolution: {integrity: sha512-gRf5c+A7QiOG3UwLyOOtyJMD31JJhMjBvpfhAitPAoqZFcOeK3Kc1Veg1z/trmt+2P6F/biT02fU19GGTS529A==}
     cpu: [s390x]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-gnu@4.48.1':
-    resolution: {integrity: sha512-90taWXCWxTbClWuMZD0DKYohY1EovA+W5iytpE89oUPmT5O1HFdf8cuuVIylE6vCbrGdIGv85lVRzTcpTRZ+kA==}
+  '@rollup/rollup-linux-x64-gnu@4.49.0':
+    resolution: {integrity: sha512-BR7+blScdLW1h/2hB/2oXM+dhTmpW3rQt1DeSiCP9mc2NMMkqVgjIN3DDsNpKmezffGC9R8XKVOLmBkRUcK/sA==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-linux-x64-musl@4.48.1':
-    resolution: {integrity: sha512-2Gu29SkFh1FfTRuN1GR1afMuND2GKzlORQUP3mNMJbqdndOg7gNsa81JnORctazHRokiDzQ5+MLE5XYmZW5VWg==}
+  '@rollup/rollup-linux-x64-musl@4.49.0':
+    resolution: {integrity: sha512-hDMOAe+6nX3V5ei1I7Au3wcr9h3ktKzDvF2ne5ovX8RZiAHEtX1A5SNNk4zt1Qt77CmnbqT+upb/umzoPMWiPg==}
     cpu: [x64]
     os: [linux]
 
-  '@rollup/rollup-win32-arm64-msvc@4.48.1':
-    resolution: {integrity: sha512-6kQFR1WuAO50bxkIlAVeIYsz3RUx+xymwhTo9j94dJ+kmHe9ly7muH23sdfWduD0BA8pD9/yhonUvAjxGh34jQ==}
+  '@rollup/rollup-win32-arm64-msvc@4.49.0':
+    resolution: {integrity: sha512-wkNRzfiIGaElC9kXUT+HLx17z7D0jl+9tGYRKwd8r7cUqTL7GYAvgUY++U2hK6Ar7z5Z6IRRoWC8kQxpmM7TDA==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.48.1':
-    resolution: {integrity: sha512-RUyZZ/mga88lMI3RlXFs4WQ7n3VyU07sPXmMG7/C1NOi8qisUg57Y7LRarqoGoAiopmGmChUhSwfpvQ3H5iGSQ==}
+  '@rollup/rollup-win32-ia32-msvc@4.49.0':
+    resolution: {integrity: sha512-gq5aW/SyNpjp71AAzroH37DtINDcX1Qw2iv9Chyz49ZgdOP3NV8QCyKZUrGsYX9Yyggj5soFiRCgsL3HwD8TdA==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.48.1':
-    resolution: {integrity: sha512-8a/caCUN4vkTChxkaIJcMtwIVcBhi4X2PQRoT+yCK3qRYaZ7cURrmJFL5Ux9H9RaMIXj9RuihckdmkBX3zZsgg==}
+  '@rollup/rollup-win32-x64-msvc@4.49.0':
+    resolution: {integrity: sha512-gEtqFbzmZLFk2xKh7g0Rlo8xzho8KrEFEkzvHbfUGkrgXOpZ4XagQ6n+wIZFNh1nTb8UD16J4nFSFKXYgnbdBg==}
     cpu: [x64]
     os: [win32]
 
@@ -1401,13 +1401,13 @@ packages:
       vue:
         optional: true
 
-  '@vueuse/core@13.7.0':
-    resolution: {integrity: sha512-myagn09+c6BmS6yHc1gTwwsdZilAovHslMjyykmZH3JNyzI5HoWhv114IIdytXiPipdHJ2gDUx0PB93jRduJYg==}
+  '@vueuse/core@13.8.0':
+    resolution: {integrity: sha512-rmBcgpEpxY0ZmyQQR94q1qkUcHREiLxQwNyWrtjMDipD0WTH/JBcAt0gdcn2PsH0SA76ec291cHFngmyaBhlxA==}
     peerDependencies:
       vue: ^3.5.0
 
-  '@vueuse/integrations@13.7.0':
-    resolution: {integrity: sha512-Na5p0ONLepNV/xCBi8vBMuzCOZh9CFT/OHnrUlABWXgWTWSHM3wrVaLS1xvAijPLU5B1ysyJDDW/hKak80oLGA==}
+  '@vueuse/integrations@13.8.0':
+    resolution: {integrity: sha512-64mD5Q7heVkr8JsqBFDh9xnQJrPLmWJghy8Qtj9UeLosQL9n+JYTcS7d+eNsEVwuvZvxfF7hUSi87jABm/eYpw==}
     peerDependencies:
       async-validator: ^4
       axios: ^1
@@ -1448,11 +1448,11 @@ packages:
       universal-cookie:
         optional: true
 
-  '@vueuse/metadata@13.7.0':
-    resolution: {integrity: sha512-8okFhS/1ite8EwUdZZfvTYowNTfXmVCOrBFlA31O0HD8HKXhY+WtTRyF0LwbpJfoFPc+s9anNJIXMVrvP7UTZg==}
+  '@vueuse/metadata@13.8.0':
+    resolution: {integrity: sha512-BYMp3Gp1kBUPv7AfQnJYP96mkX7g7cKdTIgwv/Jgd+pfQhz678naoZOAcknRtPLP4cFblDDW7rF4e3KFa+PfIA==}
 
-  '@vueuse/shared@13.7.0':
-    resolution: {integrity: sha512-Wi2LpJi4UA9kM0OZ0FCZslACp92HlVNw1KPaDY6RAzvQ+J1s7seOtcOpmkfbD5aBSmMn9NvOakc8ZxMxmDXTIg==}
+  '@vueuse/shared@13.8.0':
+    resolution: {integrity: sha512-x4nfM0ykW+RmNJ4/1IzZsuLuWWrNTxlTWUiehTGI54wnOxIgI9EDdu/O5S77ac6hvQ3hk2KpOVFHaM0M796Kbw==}
     peerDependencies:
       vue: ^3.5.0
 
@@ -1688,8 +1688,8 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
-  electron-to-chromium@1.5.209:
-    resolution: {integrity: sha512-Xoz0uMrim9ZETCQt8UgM5FxQF9+imA7PBpokoGcZloA1uw2LeHzTlip5cb5KOAsXZLjh/moN2vReN3ZjJmjI9A==}
+  electron-to-chromium@1.5.210:
+    resolution: {integrity: sha512-20kSVv1tyNBN2VFsjCIJZfyvxqo7ylHPrJLME040f/030lzNMA7uQNpxtqJjWSNpccD8/2sqe53EAjrFPvQmjw==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -2431,8 +2431,8 @@ packages:
     engines: {node: '>=10.0.0'}
     hasBin: true
 
-  rollup@4.48.1:
-    resolution: {integrity: sha512-jVG20NvbhTYDkGAty2/Yh7HK6/q3DGSRH4o8ALKGArmMuaauM9kLfoMZ+WliPwA5+JHr2lTn3g557FxBV87ifg==}
+  rollup@4.49.0:
+    resolution: {integrity: sha512-3IVq0cGJ6H7fKXXEdVt+RcYvRCt8beYY9K1760wGQwSAHZcS9eot1zDG5axUbcp/kWRi5zKIIDX8MoKv/TzvZA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -3927,64 +3927,64 @@ snapshots:
     optionalDependencies:
       rollup: 2.79.2
 
-  '@rollup/rollup-android-arm-eabi@4.48.1':
+  '@rollup/rollup-android-arm-eabi@4.49.0':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.48.1':
+  '@rollup/rollup-android-arm64@4.49.0':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.48.1':
+  '@rollup/rollup-darwin-arm64@4.49.0':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.48.1':
+  '@rollup/rollup-darwin-x64@4.49.0':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.48.1':
+  '@rollup/rollup-freebsd-arm64@4.49.0':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.48.1':
+  '@rollup/rollup-freebsd-x64@4.49.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.48.1':
+  '@rollup/rollup-linux-arm-gnueabihf@4.49.0':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.48.1':
+  '@rollup/rollup-linux-arm-musleabihf@4.49.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.48.1':
+  '@rollup/rollup-linux-arm64-gnu@4.49.0':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.48.1':
+  '@rollup/rollup-linux-arm64-musl@4.49.0':
     optional: true
 
-  '@rollup/rollup-linux-loongarch64-gnu@4.48.1':
+  '@rollup/rollup-linux-loongarch64-gnu@4.49.0':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.48.1':
+  '@rollup/rollup-linux-ppc64-gnu@4.49.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.48.1':
+  '@rollup/rollup-linux-riscv64-gnu@4.49.0':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.48.1':
+  '@rollup/rollup-linux-riscv64-musl@4.49.0':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.48.1':
+  '@rollup/rollup-linux-s390x-gnu@4.49.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.48.1':
+  '@rollup/rollup-linux-x64-gnu@4.49.0':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.48.1':
+  '@rollup/rollup-linux-x64-musl@4.49.0':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.48.1':
+  '@rollup/rollup-win32-arm64-msvc@4.49.0':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.48.1':
+  '@rollup/rollup-win32-ia32-msvc@4.49.0':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.48.1':
+  '@rollup/rollup-win32-x64-msvc@4.49.0':
     optional: true
 
   '@surma/rollup-plugin-off-main-thread@2.2.3':
@@ -4268,24 +4268,24 @@ snapshots:
       typescript: 5.9.2
       vue: 3.5.20(typescript@5.9.2)
 
-  '@vueuse/core@13.7.0(vue@3.5.20(typescript@5.9.2))':
+  '@vueuse/core@13.8.0(vue@3.5.20(typescript@5.9.2))':
     dependencies:
       '@types/web-bluetooth': 0.0.21
-      '@vueuse/metadata': 13.7.0
-      '@vueuse/shared': 13.7.0(vue@3.5.20(typescript@5.9.2))
+      '@vueuse/metadata': 13.8.0
+      '@vueuse/shared': 13.8.0(vue@3.5.20(typescript@5.9.2))
       vue: 3.5.20(typescript@5.9.2)
 
-  '@vueuse/integrations@13.7.0(universal-cookie@8.0.1)(vue@3.5.20(typescript@5.9.2))':
+  '@vueuse/integrations@13.8.0(universal-cookie@8.0.1)(vue@3.5.20(typescript@5.9.2))':
     dependencies:
-      '@vueuse/core': 13.7.0(vue@3.5.20(typescript@5.9.2))
-      '@vueuse/shared': 13.7.0(vue@3.5.20(typescript@5.9.2))
+      '@vueuse/core': 13.8.0(vue@3.5.20(typescript@5.9.2))
+      '@vueuse/shared': 13.8.0(vue@3.5.20(typescript@5.9.2))
       vue: 3.5.20(typescript@5.9.2)
     optionalDependencies:
       universal-cookie: 8.0.1
 
-  '@vueuse/metadata@13.7.0': {}
+  '@vueuse/metadata@13.8.0': {}
 
-  '@vueuse/shared@13.7.0(vue@3.5.20(typescript@5.9.2))':
+  '@vueuse/shared@13.8.0(vue@3.5.20(typescript@5.9.2))':
     dependencies:
       vue: 3.5.20(typescript@5.9.2)
 
@@ -4387,7 +4387,7 @@ snapshots:
   browserslist@4.25.3:
     dependencies:
       caniuse-lite: 1.0.30001737
-      electron-to-chromium: 1.5.209
+      electron-to-chromium: 1.5.210
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.3)
 
@@ -4518,7 +4518,7 @@ snapshots:
     dependencies:
       jake: 10.9.4
 
-  electron-to-chromium@1.5.209: {}
+  electron-to-chromium@1.5.210: {}
 
   emoji-regex@8.0.0: {}
 
@@ -5088,7 +5088,7 @@ snapshots:
 
   neverthrow@8.2.0:
     optionalDependencies:
-      '@rollup/rollup-linux-x64-gnu': 4.48.1
+      '@rollup/rollup-linux-x64-gnu': 4.49.0
 
   node-releases@2.0.19: {}
 
@@ -5294,30 +5294,30 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  rollup@4.48.1:
+  rollup@4.49.0:
     dependencies:
       '@types/estree': 1.0.8
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.48.1
-      '@rollup/rollup-android-arm64': 4.48.1
-      '@rollup/rollup-darwin-arm64': 4.48.1
-      '@rollup/rollup-darwin-x64': 4.48.1
-      '@rollup/rollup-freebsd-arm64': 4.48.1
-      '@rollup/rollup-freebsd-x64': 4.48.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.48.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.48.1
-      '@rollup/rollup-linux-arm64-gnu': 4.48.1
-      '@rollup/rollup-linux-arm64-musl': 4.48.1
-      '@rollup/rollup-linux-loongarch64-gnu': 4.48.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.48.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.48.1
-      '@rollup/rollup-linux-riscv64-musl': 4.48.1
-      '@rollup/rollup-linux-s390x-gnu': 4.48.1
-      '@rollup/rollup-linux-x64-gnu': 4.48.1
-      '@rollup/rollup-linux-x64-musl': 4.48.1
-      '@rollup/rollup-win32-arm64-msvc': 4.48.1
-      '@rollup/rollup-win32-ia32-msvc': 4.48.1
-      '@rollup/rollup-win32-x64-msvc': 4.48.1
+      '@rollup/rollup-android-arm-eabi': 4.49.0
+      '@rollup/rollup-android-arm64': 4.49.0
+      '@rollup/rollup-darwin-arm64': 4.49.0
+      '@rollup/rollup-darwin-x64': 4.49.0
+      '@rollup/rollup-freebsd-arm64': 4.49.0
+      '@rollup/rollup-freebsd-x64': 4.49.0
+      '@rollup/rollup-linux-arm-gnueabihf': 4.49.0
+      '@rollup/rollup-linux-arm-musleabihf': 4.49.0
+      '@rollup/rollup-linux-arm64-gnu': 4.49.0
+      '@rollup/rollup-linux-arm64-musl': 4.49.0
+      '@rollup/rollup-linux-loongarch64-gnu': 4.49.0
+      '@rollup/rollup-linux-ppc64-gnu': 4.49.0
+      '@rollup/rollup-linux-riscv64-gnu': 4.49.0
+      '@rollup/rollup-linux-riscv64-musl': 4.49.0
+      '@rollup/rollup-linux-s390x-gnu': 4.49.0
+      '@rollup/rollup-linux-x64-gnu': 4.49.0
+      '@rollup/rollup-linux-x64-musl': 4.49.0
+      '@rollup/rollup-win32-arm64-msvc': 4.49.0
+      '@rollup/rollup-win32-ia32-msvc': 4.49.0
+      '@rollup/rollup-win32-x64-msvc': 4.49.0
       fsevents: 2.3.3
 
   safe-array-concat@1.1.3:
@@ -5696,7 +5696,7 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
-      rollup: 4.48.1
+      rollup: 4.49.0
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 24.3.0

--- a/src/App.vue
+++ b/src/App.vue
@@ -16,8 +16,7 @@ import {
   CardImageModal,
   DeckManagementModal,
 } from "./components";
-import { cleanupStaleEntries } from "./utils";
-import { CACHE_CLEANUP_INTERVAL } from "./utils/image";
+import { cleanupStaleEntries, CACHE_CLEANUP_INTERVAL } from "./utils";
 
 // コンポーザブル
 import { useImageModal } from "./composables/useImageModal";

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,4 +1,8 @@
 <script setup lang="ts">
+// App.vue
+// 画面全体のレイアウトと各ストア/セクション/モーダルの配線を担うコンテナ。
+// 初期化（カード読込・デッキ生成）とキャッシュ掃除などの副作用を集約し、
+// 画像モーダルには deckCards を外部参照として渡してスワイプナビゲーションの基準を統一する。
 import { onMounted, computed, useTemplateRef, watch } from "vue";
 import { useIntervalFn } from "@vueuse/core";
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,7 +46,7 @@ const {
   openImageModal: openModal,
   closeImageModal,
   handleCardNavigation,
-} = useImageModal();
+} = useImageModal(deckCards);
 
 // アプリケーションの初期化
 onMounted(appStore.initializeApp);

--- a/src/App.vue
+++ b/src/App.vue
@@ -43,7 +43,7 @@ const {
   selectedCard,
   selectedImage,
   selectedIndex,
-  openImageModal: openModal,
+  openImageModal,
   closeImageModal,
   handleCardNavigation,
 } = useImageModal(deckCards);
@@ -53,18 +53,6 @@ onMounted(appStore.initializeApp);
 
 // 画像キャッシュの定期的なクリーンアップ
 useIntervalFn(cleanupStaleEntries, CACHE_CLEANUP_INTERVAL, { immediate: true });
-
-// 画像モーダルを開く（デッキカードを渡す）
-const openImageModal = (cardId: string) => {
-  // 入力ガード（空文字や未存在IDなら何もしない）
-  if (!cardId) return;
-  openModal(cardId);
-};
-
-// カードナビゲーション（デッキカードを渡す）
-const navigateCard = (direction: "previous" | "next") => {
-  handleCardNavigation(direction);
-};
 
 watch(
   deckSectionRef,
@@ -179,7 +167,7 @@ const cardImageModalProps = computed(() => ({
     <CardImageModal
       v-bind="cardImageModalProps"
       @close="closeImageModal"
-      @navigate="navigateCard"
+      @navigate="handleCardNavigation"
     />
 
     <!-- デッキ管理モーダル -->

--- a/src/App.vue
+++ b/src/App.vue
@@ -62,9 +62,9 @@ const openImageModal = (cardId: string) => {
 };
 
 // カードナビゲーション（デッキカードを渡す）
- const navigateCard = (direction: "previous" | "next") => {
-   handleCardNavigation(direction);
- };
+const navigateCard = (direction: "previous" | "next") => {
+  handleCardNavigation(direction);
+};
 
 watch(
   deckSectionRef,

--- a/src/components/layout/CardListSection.vue
+++ b/src/components/layout/CardListSection.vue
@@ -1,3 +1,10 @@
++<!--
++  CardListSection.vue
++  目的: カード一覧の表示/クリック操作(追加・枚数増加)と画像の長押し拡大を提供する純UI層
++  入力: Props.availableCards, sortedAndFilteredCards, deckCards, isLoading, error
++  出力: Emits(openFilter, addCard, incrementCard, decrementCard, openImageModal)
++  留意: ドメイン制約(MAX_CARD_COPIES)は表示制御のみで、最終判定は親/ドメイン層に委譲
++-->
 <script setup lang="ts">
 import { reactive, watchEffect, computed } from "vue";
 import { GAME_CONSTANTS } from "../../constants";
@@ -266,6 +273,7 @@ watchEffect((onCleanup) => {
             @click="emit('incrementCard', card.id)"
             class="w-6 h-6 sm:w-8 sm:h-8 bg-gradient-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 text-white rounded-full flex items-center justify-center leading-none transition-all duration-200 shadow-lg hover:shadow-emerald-500/25 disabled:from-slate-600 disabled:to-slate-700 disabled:cursor-not-allowed"
             :disabled="getCardInDeck(card.id) >= GAME_CONSTANTS.MAX_CARD_COPIES"
+            :aria-disabled="getCardInDeck(card.id) >= GAME_CONSTANTS.MAX_CARD_COPIES"
           >
             <svg
               class="w-3 h-3 sm:w-4 sm:h-4"

--- a/src/components/layout/CardListSection.vue
+++ b/src/components/layout/CardListSection.vue
@@ -273,7 +273,9 @@ watchEffect((onCleanup) => {
             @click="emit('incrementCard', card.id)"
             class="w-6 h-6 sm:w-8 sm:h-8 bg-gradient-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 text-white rounded-full flex items-center justify-center leading-none transition-all duration-200 shadow-lg hover:shadow-emerald-500/25 disabled:from-slate-600 disabled:to-slate-700 disabled:cursor-not-allowed"
             :disabled="getCardInDeck(card.id) >= GAME_CONSTANTS.MAX_CARD_COPIES"
-            :aria-disabled="getCardInDeck(card.id) >= GAME_CONSTANTS.MAX_CARD_COPIES"
+            :aria-disabled="
+              getCardInDeck(card.id) >= GAME_CONSTANTS.MAX_CARD_COPIES
+            "
           >
             <svg
               class="w-3 h-3 sm:w-4 sm:h-4"

--- a/src/components/layout/CardListSection.vue
+++ b/src/components/layout/CardListSection.vue
@@ -220,6 +220,7 @@ watchEffect((onCleanup) => {
             @error="handleImageError"
             :alt="card.name"
             loading="lazy"
+            crossorigin="anonymous"
             class="block w-full h-full object-cover transition-transform duration-200 select-none"
           />
           <div

--- a/src/components/layout/CardListSection.vue
+++ b/src/components/layout/CardListSection.vue
@@ -46,10 +46,10 @@ const openImageModal = (cardId: string) => {
 
 // カードクリック処理
 const handleCardClick = (card: Card) => {
-  const current = getCardInDeck(card.id);
-  if (current === 0) {
+  const currentCount = getCardInDeck(card.id);
+  if (currentCount === 0) {
     emit("addCard", card);
-  } else if (current < 4) {
+  } else if (currentCount < 4) {
     emit("incrementCard", card.id);
   }
 };

--- a/src/components/layout/CardListSection.vue
+++ b/src/components/layout/CardListSection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { reactive, watchEffect, computed } from "vue";
+import { GAME_CONSTANTS } from "../../constants/game";
 import type { Card, DeckCard } from "../../types";
 import { handleImageError, getCardImageUrlSafe } from "../../utils";
 import { onLongPress } from "@vueuse/core";
@@ -49,7 +50,7 @@ const handleCardClick = (card: Card) => {
   const currentCount = getCardInDeck(card.id);
   if (currentCount === 0) {
     emit("addCard", card);
-  } else if (currentCount < 4) {
+  } else if (currentCount < GAME_CONSTANTS.MAX_CARD_COPIES) {
     emit("incrementCard", card.id);
   }
 };
@@ -263,7 +264,7 @@ watchEffect((onCleanup) => {
           <button
             @click="emit('incrementCard', card.id)"
             class="w-6 h-6 sm:w-8 sm:h-8 bg-gradient-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 text-white rounded-full flex items-center justify-center leading-none transition-all duration-200 shadow-lg hover:shadow-emerald-500/25 disabled:from-slate-600 disabled:to-slate-700 disabled:cursor-not-allowed"
-            :disabled="getCardInDeck(card.id) >= 4"
+            :disabled="getCardInDeck(card.id) >= GAME_CONSTANTS.MAX_CARD_COPIES"
           >
             <svg
               class="w-3 h-3 sm:w-4 sm:h-4"

--- a/src/components/layout/CardListSection.vue
+++ b/src/components/layout/CardListSection.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { reactive, watchEffect, computed } from "vue";
-import { GAME_CONSTANTS } from "../../constants/game";
+import { GAME_CONSTANTS } from "../../constants";
 import type { Card, DeckCard } from "../../types";
 import { handleImageError, getCardImageUrlSafe } from "../../utils";
 import { onLongPress } from "@vueuse/core";

--- a/src/components/layout/DeckSection.vue
+++ b/src/components/layout/DeckSection.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
 import { computed, useTemplateRef, ref, watchEffect } from "vue";
 import { DeckExportContainer } from "../index";
-import { handleImageError } from "../../utils/image";
-import { getCardImageUrlSafe } from "../../utils";
+import { GAME_CONSTANTS } from "../../constants";
+import { getCardImageUrlSafe, handleImageError } from "../../utils";
 import { useDeckOperations } from "../../composables/useDeckOperations";
-import { useDeckStore } from "../../stores/deck";
+import { useDeckStore } from "../../stores";
 import { onLongPress } from "@vueuse/core";
 
 // Vue 3.5の新機能: 改善されたdefineProps with better TypeScript support
@@ -309,7 +309,7 @@ defineExpose({
           <button
             @click="handleIncrementCard(item.card.id)"
             class="w-6 h-6 sm:w-8 sm:h-8 bg-gradient-to-r from-emerald-500 to-emerald-600 hover:from-emerald-600 hover:to-emerald-700 text-white rounded-full flex items-center justify-center leading-none transition-all duration-200 shadow-lg hover:shadow-emerald-500/25 disabled:from-slate-600 disabled:to-slate-700 disabled:cursor-not-allowed"
-            :disabled="item.count >= 4"
+            :disabled="item.count >= GAME_CONSTANTS.MAX_CARD_COPIES"
           >
             <svg
               class="w-3 h-3 sm:w-4 sm:h-4"

--- a/src/components/layout/DeckSection.vue
+++ b/src/components/layout/DeckSection.vue
@@ -84,11 +84,6 @@ watchEffect((onCleanup) => {
   });
 });
 
-// カードデクリメント処理（ハンドラークリーンアップ付き）
-const decrementCard = (cardId: string) => {
-  handleDecrementCard(cardId);
-};
-
 const resetDeck = () => {
   emit("resetDeck");
 };
@@ -114,7 +109,6 @@ const getDeckProgressColor = (count: number) => {
 // エクスポート用
 defineExpose({
   exportContainer,
-  decrementCard,
   resetDeck,
   updateDeckName,
 });
@@ -290,7 +284,7 @@ defineExpose({
           class="absolute bottom-2 w-full px-1 flex items-center justify-center gap-1"
         >
           <button
-            @click="decrementCard(item.card.id)"
+            @click="handleDecrementCard(item.card.id)"
             class="w-6 h-6 sm:w-8 sm:h-8 bg-gradient-to-r from-red-500 to-red-600 hover:from-red-600 hover:to-red-700 text-white rounded-full flex items-center justify-center leading-none transition-all duration-200 shadow-lg hover:shadow-red-500/25"
           >
             <svg

--- a/src/components/layout/DeckSection.vue
+++ b/src/components/layout/DeckSection.vue
@@ -5,6 +5,7 @@ import { GAME_CONSTANTS } from "../../constants";
 import { getCardImageUrlSafe, handleImageError } from "../../utils";
 import { useDeckOperations } from "../../composables/useDeckOperations";
 import { useDeckStore } from "../../stores";
+import { storeToRefs } from "pinia";
 import { onLongPress } from "@vueuse/core";
 
 // Vue 3.5の新機能: 改善されたdefineProps with better TypeScript support
@@ -34,10 +35,8 @@ const {
 } = useDeckOperations();
 
 // 計算プロパティ（ストアから直接取得）- Vue 3.5の改善されたreactivity
-const deckCards = deckStore.deckCards;
-const deckName = deckStore.deckName;
-const sortedDeckCards = deckStore.sortedDeckCards;
-const totalDeckCards = deckStore.totalDeckCards;
+const { deckCards, deckName, sortedDeckCards, totalDeckCards } =
+  storeToRefs(deckStore);
 
 // デッキ名の更新（ストアメソッドを直接使用）
 const updateDeckName = (value: string) => {
@@ -70,7 +69,7 @@ const setDeckCardRef = (el: unknown, cardId: string) => {
 
 watchEffect((onCleanup) => {
   const stops: Function[] = [];
-  sortedDeckCards.forEach((item) => {
+  sortedDeckCards.value.forEach((item) => {
     const el = deckCardRefs.value.get(item.card.id);
     if (el) {
       const stop = onLongPress(el, () => openImageModal(item.card.id), {
@@ -234,14 +233,16 @@ defineExpose({
         >
           {{ totalDeckCards }}
         </span>
-        <span class="text-xs text-slate-400">/ 60</span>
+        <span class="text-xs text-slate-400"
+          >/ {{ GAME_CONSTANTS.MAX_DECK_SIZE }}</span
+        >
 
         <div class="w-12 sm:w-16 h-1 bg-slate-700 rounded-full overflow-hidden">
           <div
             class="h-full transition-all duration-300 rounded-full"
             :class="getDeckProgressColor(totalDeckCards)"
             :style="{
-              width: `${Math.min((totalDeckCards / 60) * 100, 100)}%`,
+              width: `${Math.min((totalDeckCards / GAME_CONSTANTS.MAX_DECK_SIZE) * 100, 100)}%`,
             }"
           ></div>
         </div>

--- a/src/components/layout/DeckSection.vue
+++ b/src/components/layout/DeckSection.vue
@@ -270,6 +270,7 @@ defineExpose({
             @error="handleImageError"
             :alt="item.card.name"
             loading="lazy"
+            crossorigin="anonymous"
             class="block w-full h-full object-cover transition-transform duration-200 select-none"
           />
           <div

--- a/src/components/layout/DeckSection.vue
+++ b/src/components/layout/DeckSection.vue
@@ -34,10 +34,10 @@ const {
 } = useDeckOperations();
 
 // 計算プロパティ（ストアから直接取得）- Vue 3.5の改善されたreactivity
-const deckCards = computed(() => deckStore.deckCards);
-const deckName = computed(() => deckStore.deckName);
-const sortedDeckCards = computed(() => deckStore.sortedDeckCards);
-const totalDeckCards = computed(() => deckStore.totalDeckCards);
+const deckCards = deckStore.deckCards;
+const deckName = deckStore.deckName;
+const sortedDeckCards = deckStore.sortedDeckCards;
+const totalDeckCards = deckStore.totalDeckCards;
 
 // デッキ名の更新（ストアメソッドを直接使用）
 const updateDeckName = (value: string) => {
@@ -70,7 +70,7 @@ const setDeckCardRef = (el: unknown, cardId: string) => {
 
 watchEffect((onCleanup) => {
   const stops: Function[] = [];
-  sortedDeckCards.value.forEach((item) => {
+  sortedDeckCards.forEach((item) => {
     const el = deckCardRefs.value.get(item.card.id);
     if (el) {
       const stop = onLongPress(el, () => openImageModal(item.card.id), {
@@ -88,21 +88,17 @@ const resetDeck = () => {
   emit("resetDeck");
 };
 
-// デッキ枚数の色分け計算
-const MAX_DECK_SIZE = 60;
-const WARNING_THRESHOLD = 50;
-
 const getDeckCountColor = (count: number) => {
-  if (count === MAX_DECK_SIZE) return "text-green-400";
-  if (count > MAX_DECK_SIZE) return "text-red-400";
-  if (count > WARNING_THRESHOLD) return "text-yellow-400";
+  if (count === GAME_CONSTANTS.MAX_DECK_SIZE) return "text-green-400";
+  if (count > GAME_CONSTANTS.MAX_DECK_SIZE) return "text-red-400";
+  if (count > (GAME_CONSTANTS.MAX_DECK_SIZE * 5) / 6) return "text-yellow-400";
   return "text-slate-100";
 };
 
 const getDeckProgressColor = (count: number) => {
-  if (count === MAX_DECK_SIZE) return "bg-green-500";
-  if (count > MAX_DECK_SIZE) return "bg-red-500";
-  if (count > WARNING_THRESHOLD) return "bg-yellow-500";
+  if (count === GAME_CONSTANTS.MAX_DECK_SIZE) return "bg-green-500";
+  if (count > GAME_CONSTANTS.MAX_DECK_SIZE) return "bg-red-500";
+  if (count > (GAME_CONSTANTS.MAX_DECK_SIZE * 5) / 6) return "bg-yellow-500";
   return "bg-blue-500";
 };
 

--- a/src/components/modals/CardImageModal.vue
+++ b/src/components/modals/CardImageModal.vue
@@ -30,6 +30,7 @@
           v-if="imageSrc"
           :src="imageSrc"
           :alt="imageAltText"
+          crossorigin="anonymous"
           class="max-w-full max-h-full object-contain shadow-2xl"
           @error="handleImageError"
           @load="isImageLoading = false"

--- a/src/components/modals/CardImageModal.vue
+++ b/src/components/modals/CardImageModal.vue
@@ -97,6 +97,7 @@ const hasNextCard = computed(() => {
 
 // useSwipeの適用
 useSwipe(imageContainer, {
+  threshold: 40,
   onSwipeEnd(_, direction) {
     if (direction === "left" && hasNextCard.value) {
       navigateToNext();

--- a/src/components/modals/CardImageModal.vue
+++ b/src/components/modals/CardImageModal.vue
@@ -44,7 +44,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from "vue";
 import { useSwipe } from "@vueuse/core";
-import { handleImageError } from "../../utils/image";
+import { handleImageError } from "../../utils";
 import type { Card } from "../../types";
 
 interface Props {

--- a/src/components/modals/CardImageModal.vue
+++ b/src/components/modals/CardImageModal.vue
@@ -25,13 +25,7 @@
       </div>
 
       <!-- カード画像 -->
-      <div
-        ref="imageContainer"
-        class="touch-pan-y relative"
-        @touchstart="handleTouchStart"
-        @touchmove="handleTouchMove"
-        @touchend="handleTouchEnd"
-      >
+      <div ref="imageContainer" class="touch-pan-y relative">
         <img
           v-if="imageSrc"
           :src="imageSrc"
@@ -49,6 +43,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onMounted, onUnmounted, nextTick } from "vue";
+import { useSwipe } from "@vueuse/core";
 import { handleImageError } from "../../utils/image";
 import type { Card } from "../../types";
 
@@ -83,11 +78,6 @@ watch(
   },
 );
 
-// スワイプ関連の状態
-const touchStartX = ref<number | null>(null);
-const touchStartY = ref<number | null>(null);
-const minSwipeDistance = 50; // 最小スワイプ距離（px）
-
 // ナビゲーション可能性を計算
 const hasPreviousCard = computed(() => {
   if (props.cardIndex === null || props.cardIndex === undefined) return false;
@@ -105,55 +95,16 @@ const hasNextCard = computed(() => {
   return props.cardIndex < props.totalCards - 1;
 });
 
-// スワイプハンドラー
-const handleTouchStart = (event: TouchEvent) => {
-  if (event.touches.length === 1) {
-    touchStartX.value = event.touches[0].clientX;
-    touchStartY.value = event.touches[0].clientY;
-  }
-};
-
-const handleTouchMove = (event: TouchEvent) => {
-  if (touchStartX.value === null || touchStartY.value === null) return;
-
-  const touch = event.touches[0];
-  const deltaX = touch.clientX - touchStartX.value;
-  const deltaY = touch.clientY - touchStartY.value;
-
-  // 水平方向の移動が縦方向より大きい場合のみpreventDefaultを呼び出す
-  if (Math.abs(deltaX) > Math.abs(deltaY)) {
-    event.preventDefault();
-  }
-};
-
-const handleTouchEnd = (event: TouchEvent) => {
-  if (touchStartX.value === null || touchStartY.value === null) return;
-
-  const touch = event.changedTouches[0];
-  const deltaX = touch.clientX - touchStartX.value;
-  const deltaY = touch.clientY - touchStartY.value;
-
-  // 縦方向のスワイプが横方向よりも大きい場合は処理しない
-  if (Math.abs(deltaY) > Math.abs(deltaX)) {
-    touchStartX.value = null;
-    touchStartY.value = null;
-    return;
-  }
-
-  // 最小距離以上のスワイプかチェック
-  if (Math.abs(deltaX) >= minSwipeDistance) {
-    if (deltaX > 0 && hasPreviousCard.value) {
-      // 右スワイプ - 前のカード
-      navigateToPrevious();
-    } else if (deltaX < 0 && hasNextCard.value) {
-      // 左スワイプ - 次のカード
+// useSwipeの適用
+useSwipe(imageContainer, {
+  onSwipeEnd(_, direction) {
+    if (direction === "left" && hasNextCard.value) {
       navigateToNext();
+    } else if (direction === "right" && hasPreviousCard.value) {
+      navigateToPrevious();
     }
-  }
-
-  touchStartX.value = null;
-  touchStartY.value = null;
-};
+  },
+});
 
 // ナビゲーション関数
 const navigateToPrevious = () => {

--- a/src/components/modals/ConfirmModal.vue
+++ b/src/components/modals/ConfirmModal.vue
@@ -51,7 +51,8 @@
 </template>
 
 <script setup lang="ts">
-import { onMounted, onUnmounted } from "vue";
+import { watch } from "vue";
+import { useEventListener } from "@vueuse/core";
 
 interface Props {
   isVisible: boolean;
@@ -93,19 +94,24 @@ const onBackdropClick = () => {
 };
 
 // ESCキーでモーダルを閉じる
-const handleKeyDown = (event: KeyboardEvent) => {
+useEventListener(document, "keydown", (event: KeyboardEvent) => {
   if (event.key === "Escape" && props.isVisible && !props.loading) {
     emit("cancel");
   }
-};
-
-onMounted(() => {
-  document.addEventListener("keydown", handleKeyDown);
 });
 
-onUnmounted(() => {
-  document.removeEventListener("keydown", handleKeyDown);
-});
+// モーダルの表示状態に応じてbodyのスクロールを制御
+watch(
+  () => props.isVisible,
+  (newVal) => {
+    if (newVal) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+  },
+  { immediate: true },
+);
 </script>
 
 <style scoped>

--- a/src/components/modals/ConfirmModal.vue
+++ b/src/components/modals/ConfirmModal.vue
@@ -3,7 +3,6 @@
     v-if="isVisible"
     class="fixed inset-0 bg-black/50 flex items-center justify-center z-[1000] animate-fadeIn"
     @click="onBackdropClick"
-    @keydown.esc="onCancel"
     tabindex="0"
     role="dialog"
     aria-modal="true"
@@ -52,7 +51,7 @@
 
 <script setup lang="ts">
 import { watch } from "vue";
-import { useEventListener } from "@vueuse/core";
+import { useEventListener, useScrollLock } from "@vueuse/core";
 
 interface Props {
   isVisible: boolean;
@@ -101,14 +100,11 @@ useEventListener(document, "keydown", (event: KeyboardEvent) => {
 });
 
 // モーダルの表示状態に応じてbodyのスクロールを制御
+const isLocked = useScrollLock(document.body);
 watch(
   () => props.isVisible,
-  (newVal) => {
-    if (newVal) {
-      document.body.style.overflow = "hidden";
-    } else {
-      document.body.style.overflow = "";
-    }
+  (v) => {
+    isLocked.value = v;
   },
   { immediate: true },
 );

--- a/src/components/modals/DeckManagementModal.vue
+++ b/src/components/modals/DeckManagementModal.vue
@@ -1,9 +1,11 @@
 <script setup lang="ts">
 import { ref, computed } from "vue";
-import { useDeckManagementStore } from "../../stores/deckManagement";
-import { useDeckStore } from "../../stores/deck";
-import { useDeckCodeStore } from "../../stores/deckCode";
-import { useAppStore } from "../../stores/app";
+import {
+  useAppStore,
+  useDeckCodeStore,
+  useDeckManagementStore,
+  useDeckStore,
+} from "../../stores";
 
 const deckManagementStore = useDeckManagementStore();
 const deckStore = useDeckStore();

--- a/src/components/modals/FilterModal.vue
+++ b/src/components/modals/FilterModal.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { computed } from "vue";
-import { useFilterStore } from "../../stores/filter";
+import { useFilterStore } from "../../stores";
 import { useFilterHelpers } from "../../composables/useFilterHelpers";
-import type { CardKind, CardType } from "../../types/card";
+import type { CardKind, CardType } from "../../types";
 
 // Props（最小限に削減）
 interface Props {

--- a/src/composables/useDeckCards.ts
+++ b/src/composables/useDeckCards.ts
@@ -1,5 +1,5 @@
 import { computed, type Ref } from "vue";
-import type { DeckCard } from "../types/deck";
+import type { DeckCard } from "../types";
 
 /**
  * デッキカード関連の状態管理を提供するコンポーザブル

--- a/src/composables/useDeckCards.ts
+++ b/src/composables/useDeckCards.ts
@@ -8,10 +8,10 @@ export function useDeckCards(sortedDeckCards: Ref<readonly DeckCard[]>) {
   /**
    * デッキカードの総数を取得
    */
-  const sortedDeckCardsLength = computed(() => sortedDeckCards.value.length);
+  const sortedDeckSize = computed(() => sortedDeckCards.value.length);
 
   return {
     deckCards: sortedDeckCards,
-    sortedDeckCardsLength,
+    sortedDeckSize,
   };
 }

--- a/src/composables/useDeckOperations.ts
+++ b/src/composables/useDeckOperations.ts
@@ -4,13 +4,11 @@
  * メモ化による最適化とエラーハンドリングを含む
  */
 import { computed, type ComputedRef } from "vue";
-import type { Card } from "../types/card";
-import type { DeckCard, DeckOperation } from "../types/deck";
-import * as DeckDomain from "../domain/deck";
-import { useDeckStore } from "../stores/deck";
-import { useCardsStore } from "../stores/cards";
+import type { Card, DeckCard, DeckOperation } from "../types";
+import * as DeckDomain from "../domain";
+import { useCardsStore, useDeckStore } from "../stores";
 import { useMemoize } from "@vueuse/core";
-import { createErrorHandler } from "../utils/errorHandler"; // createErrorHandler を追加
+import { createErrorHandler } from "../utils";
 
 /**
  * 安全なハッシュ関数（64bitバージョン）

--- a/src/composables/useFilterHelpers.ts
+++ b/src/composables/useFilterHelpers.ts
@@ -1,6 +1,5 @@
 import { computed, type ComputedRef } from "vue";
-import type { FilterCriteria } from "../types";
-import type { CardKind, CardType } from "../types/card";
+import type { CardKind, CardType, FilterCriteria } from "../types";
 
 /**
  * フィルター選択状態のヘルパー関数を提供するコンポーザブル

--- a/src/composables/useFilterHelpers.ts
+++ b/src/composables/useFilterHelpers.ts
@@ -37,7 +37,7 @@ export function useFilterHelpers(filterCriteria: ComputedRef<FilterCriteria>) {
     const criteria = filterCriteria.value;
     let count = 0;
 
-    if (criteria.text?.trim()) count++;
+    if (criteria.text.trim()) count++;
     count += criteria.kind.length;
     count += criteria.type.length;
     count += criteria.tags.length;

--- a/src/composables/useFilterHelpers.ts
+++ b/src/composables/useFilterHelpers.ts
@@ -1,3 +1,7 @@
+/**
+ * フィルター選択状態の判定用コンポーザブル
+ * - 種類/型/タグの選択判定と有効フィルター数の算出（副作用なし）
+ */
 import { computed, type ComputedRef } from "vue";
 import type { CardKind, CardType, FilterCriteria } from "../types";
 

--- a/src/composables/useImageModal.ts
+++ b/src/composables/useImageModal.ts
@@ -5,12 +5,11 @@
  * - ナビゲーション対象: deckStore.deckCards（表示順に合わせる場合は sortedDeckCards を採用）
  * - 外部I/O: 画像URLキャッシュ(globalImageUrlCache)のみ／例外は発生させない
  */
-import { shallowRef, computed, triggerRef } from "vue";
-import type { Card } from "../types";
+import { shallowRef, computed, triggerRef, type Ref } from "vue";
+import type { Card, DeckCard } from "../types";
 import { getCardImageUrlSafe } from "../utils";
 import { globalImageUrlCache } from "../utils/cache";
 import { useCardsStore } from "../stores/cards"; // useCardsStore をインポート
-import { useDeckStore } from "../stores/deck";
 
 
 /**
@@ -26,7 +25,7 @@ interface ImageModalState {
 /**
  * 画像モーダル関連の状態管理とロジックを提供するコンポーザブル
  */
-export function useImageModal() {
+export function useImageModal(sortedDeckCards: Ref<readonly DeckCard[]>) {
   // Vue 3.5の新機能: shallowRef を使用したパフォーマンス最適化
   const imageModalState = shallowRef<ImageModalState>({
     isVisible: false,
@@ -37,7 +36,6 @@ export function useImageModal() {
 
   // ストアはコンポーザブル初期化時に1度だけ取得
   const cardsStore = useCardsStore();
-  const deckStore = useDeckStore();
 
   /**
    * 画像URLをキャッシュから高速取得
@@ -70,7 +68,7 @@ export function useImageModal() {
 
     if (card) {
       // デッキ内に存在すればそのインデックス、無ければnull
-      const idxInDeck = deckStore.sortedDeckCards.findIndex(
+      const idxInDeck = sortedDeckCards.value.findIndex(
         (dc) => dc.card.id === cardId,
       );
       updateImageModalState({
@@ -100,7 +98,7 @@ export function useImageModal() {
    * カードナビゲーション
    */
  const handleCardNavigation = (direction: "previous" | "next") => {
-   const deckCards = deckStore.deckCards;   // store から直接取得
+   const deckCards = sortedDeckCards.value;   // store から直接取得
    const currentIndex = imageModalState.value.selectedIndex;
     if (currentIndex === null) return;
 

--- a/src/composables/useImageModal.ts
+++ b/src/composables/useImageModal.ts
@@ -7,9 +7,8 @@
  */
 import { shallowRef, computed, triggerRef, watch, type Ref } from "vue";
 import type { Card, DeckCard } from "../types";
-import { getCardImageUrlSafe, logger } from "../utils";
-import { globalImageUrlCache } from "../utils/cache";
-import { useCardsStore } from "../stores/cards"; // useCardsStore をインポート
+import { getCardImageUrlSafe, globalImageUrlCache, logger } from "../utils";
+import { useCardsStore } from "../stores";
 
 /**
  * 画像モーダル状態の型定義
@@ -132,7 +131,7 @@ export function useImageModal(sortedDeckCards: Ref<readonly DeckCard[]>) {
 
   // モーダル表示中にデッキが変わった場合の追従
   watch(
-    () => sortedDeckCards.value,
+    sortedDeckCards,
     (cards) => {
       if (
         !imageModalState.value.isVisible ||

--- a/src/composables/useImageModal.ts
+++ b/src/composables/useImageModal.ts
@@ -11,7 +11,6 @@ import { getCardImageUrlSafe } from "../utils";
 import { globalImageUrlCache } from "../utils/cache";
 import { useCardsStore } from "../stores/cards"; // useCardsStore をインポート
 
-
 /**
  * 画像モーダル状態の型定義
  */
@@ -97,9 +96,9 @@ export function useImageModal(sortedDeckCards: Ref<readonly DeckCard[]>) {
   /**
    * カードナビゲーション
    */
- const handleCardNavigation = (direction: "previous" | "next") => {
-   const deckCards = sortedDeckCards.value;   // store から直接取得
-   const currentIndex = imageModalState.value.selectedIndex;
+  const handleCardNavigation = (direction: "previous" | "next") => {
+    const deckCards = sortedDeckCards.value; // store から直接取得
+    const currentIndex = imageModalState.value.selectedIndex;
     if (currentIndex === null) return;
 
     let newIndex: number;

--- a/src/composables/useImageModal.ts
+++ b/src/composables/useImageModal.ts
@@ -97,7 +97,7 @@ export function useImageModal(sortedDeckCards: Ref<readonly DeckCard[]>) {
    * カードナビゲーション
    */
   const handleCardNavigation = (direction: "previous" | "next") => {
-    const deckCards = sortedDeckCards.value; // store から直接取得
+    const deckCards = sortedDeckCards.value; // 引数で受け取ったデッキから取得
     const currentIndex = imageModalState.value.selectedIndex;
     if (currentIndex === null) return;
 

--- a/src/constants/game.ts
+++ b/src/constants/game.ts
@@ -1,4 +1,4 @@
-import type { CardKind, CardType } from "../types/card";
+import type { CardKind, CardType } from "../types";
 
 export const GAME_CONSTANTS = {
   // MAX_DECK_SIZE: 60, // 60枚制限を撤廃 - 無制限でカード追加可能

--- a/src/constants/game.ts
+++ b/src/constants/game.ts
@@ -1,7 +1,7 @@
 import type { CardKind, CardType } from "../types";
 
 export const GAME_CONSTANTS = {
-  // MAX_DECK_SIZE: 60, // 60枚制限を撤廃 - 無制限でカード追加可能
+  MAX_DECK_SIZE: 60,
   MAX_CARD_COPIES: 4,
   BATCH_SIZE_FOR_PRELOAD: 10,
   MAX_DECK_CODE_LENGTH: 2000,

--- a/src/domain/card.ts
+++ b/src/domain/card.ts
@@ -8,7 +8,7 @@
  * - エラーハンドリングにはneverthrowのResult型を使用し、例外をスローしない
  */
 import { ok, err, type Result } from "neverthrow";
-import type { Card, CardKind, CardType } from "../types/card";
+import type { Card, CardKind, CardType } from "../types";
 
 /**
  * カードの検証中に発生しうるエラーを表す代数的データ型。

--- a/src/domain/card.ts
+++ b/src/domain/card.ts
@@ -59,6 +59,18 @@ export const createCard = (
     }
   }
 
+  // 空配列/重複チェック
+  if (type.length === 0) {
+    return err({
+      type: "invalidType",
+      cardType: undefined as unknown as CardType,
+    });
+  }
+  if (new Set(type).size !== type.length) {
+    // 重複を許容しない方針ならエラー、許容なら正規化しても良い
+    return err({ type: "invalidType", cardType: type[0] });
+  }
+
   // タグ検証
   let finalTags: readonly string[] | undefined = undefined;
   const processedTags = tags

--- a/src/domain/card.ts
+++ b/src/domain/card.ts
@@ -22,8 +22,8 @@ import { CARD_KINDS, CARD_TYPES } from "../constants";
 export type CardValidationError =
   | { readonly type: "invalidId"; readonly id: string }
   | { readonly type: "invalidName"; readonly name: string }
-  | { readonly type: "invalidKind"; readonly kind: CardKind }
-  | { readonly type: "invalidType"; readonly cardType: CardType } // 未知タイプ
+  | { readonly type: "invalidKind"; readonly kind: string }
+  | { readonly type: "invalidType"; readonly cardType: string }
   | { readonly type: "emptyTypeList" } // 空配列
   | { readonly type: "duplicateTypes" } // 重複
   | { readonly type: "duplicateTags"; readonly tags: readonly string[] };
@@ -51,17 +51,17 @@ export const createCard = (
     return err({ type: "invalidKind", kind });
   }
 
+  // 空配列/重複チェック
+  if (type.length === 0) return err({ type: "emptyTypeList" });
+  if (new Set(type).size !== type.length)
+    return err({ type: "duplicateTypes" });
+
   // タイプ検証（実行時）
   for (const t of type) {
     if (!CARD_TYPES.includes(t)) {
       return err({ type: "invalidType", cardType: t });
     }
   }
-
-  // 空配列/重複チェック
-  if (type.length === 0) return err({ type: "emptyTypeList" });
-  if (new Set(type).size !== type.length)
-    return err({ type: "duplicateTypes" });
 
   // タグ検証
   let finalTags: readonly string[] | undefined = undefined;

--- a/src/domain/card.ts
+++ b/src/domain/card.ts
@@ -23,10 +23,9 @@ export type CardValidationError =
   | { readonly type: "invalidId"; readonly id: string }
   | { readonly type: "invalidName"; readonly name: string }
   | { readonly type: "invalidKind"; readonly kind: CardKind }
-  | {
-      readonly type: "invalidType";
-      readonly cardType: CardType;
-    }
+  | { readonly type: "invalidType"; readonly cardType: CardType } // 未知タイプ
+  | { readonly type: "emptyTypeList" } // 空配列
+  | { readonly type: "duplicateTypes" } // 重複
   | { readonly type: "duplicateTags"; readonly tags: readonly string[] };
 
 // カード作成関数
@@ -60,16 +59,9 @@ export const createCard = (
   }
 
   // 空配列/重複チェック
-  if (type.length === 0) {
-    return err({
-      type: "invalidType",
-      cardType: undefined as unknown as CardType,
-    });
-  }
-  if (new Set(type).size !== type.length) {
-    // 重複を許容しない方針ならエラー、許容なら正規化しても良い
-    return err({ type: "invalidType", cardType: type[0] });
-  }
+  if (type.length === 0) return err({ type: "emptyTypeList" });
+  if (new Set(type).size !== type.length)
+    return err({ type: "duplicateTypes" });
 
   // タグ検証
   let finalTags: readonly string[] | undefined = undefined;

--- a/src/domain/card.ts
+++ b/src/domain/card.ts
@@ -9,6 +9,7 @@
  */
 import { ok, err, type Result } from "neverthrow";
 import type { Card, CardKind, CardType } from "../types";
+import { CARD_KINDS, CARD_TYPES } from "../constants";
 
 /**
  * カードの検証中に発生しうるエラーを表す代数的データ型。
@@ -44,6 +45,18 @@ export const createCard = (
   // 名前検証
   if (!name || name.trim().length === 0) {
     return err({ type: "invalidName", name });
+  }
+
+  // 種別検証（実行時）
+  if (!CARD_KINDS.includes(kind)) {
+    return err({ type: "invalidKind", kind });
+  }
+
+  // タイプ検証（実行時）
+  for (const t of type) {
+    if (!CARD_TYPES.includes(t)) {
+      return err({ type: "invalidType", cardType: t });
+    }
   }
 
   // タグ検証

--- a/src/domain/deck.ts
+++ b/src/domain/deck.ts
@@ -10,6 +10,7 @@
  * - パフォーマンス最適化のためにMapベースの内部処理を活用
  */
 import { ok, err, type Result } from "neverthrow";
+import { GAME_CONSTANTS } from "../constants/game";
 import type { Card } from "../types/card";
 import type {
   DeckCard,
@@ -17,9 +18,6 @@ import type {
   DeckOperation,
   DeckOperationError,
 } from "../types/deck";
-
-// ドメイン定数
-const MAX_CARD_COPIES = 4;
 
 // =============================================================================
 // Map ベースのパフォーマンス最適化関数
@@ -57,11 +55,11 @@ export const createDeckCard = (
   if (count < 1) {
     return err({ type: "invalidCardCount", cardId: card.id, count });
   }
-  if (count > MAX_CARD_COPIES) {
+  if (count > GAME_CONSTANTS.MAX_CARD_COPIES) {
     return err({
       type: "maxCountExceeded",
       cardId: card.id,
-      maxCount: MAX_CARD_COPIES,
+      maxCount: GAME_CONSTANTS.MAX_CARD_COPIES,
     });
   }
 
@@ -87,9 +85,9 @@ export const calculateDeckState = (cards: readonly DeckCard[]): DeckState => {
         `カード「${deckCard.card.name}」の枚数が無効です: ${deckCard.count}`,
       );
     }
-    if (deckCard.count > MAX_CARD_COPIES) {
+    if (deckCard.count > GAME_CONSTANTS.MAX_CARD_COPIES) {
       errors.push(
-        `カード「${deckCard.card.name}」の枚数が上限を超えています: ${deckCard.count}/${MAX_CARD_COPIES}`,
+        `カード「${deckCard.card.name}」の枚数が上限を超えています: ${deckCard.count}/${GAME_CONSTANTS.MAX_CARD_COPIES}`,
       );
     }
   }
@@ -110,11 +108,11 @@ export const addCardToDeck = (
   const existingCard = deckMap.get(cardToAdd.id);
 
   if (existingCard) {
-    if (existingCard.count >= MAX_CARD_COPIES) {
+    if (existingCard.count >= GAME_CONSTANTS.MAX_CARD_COPIES) {
       return err({
         type: "maxCountExceeded",
         cardId: cardToAdd.id,
-        maxCount: MAX_CARD_COPIES,
+        maxCount: GAME_CONSTANTS.MAX_CARD_COPIES,
       });
     }
 
@@ -158,8 +156,12 @@ export const setCardCount = (
     return ok(mapToDeckCards(deckMap));
   }
 
-  if (count > MAX_CARD_COPIES) {
-    return err({ type: "maxCountExceeded", cardId, maxCount: MAX_CARD_COPIES });
+  if (count > GAME_CONSTANTS.MAX_CARD_COPIES) {
+    return err({
+      type: "maxCountExceeded",
+      cardId,
+      maxCount: GAME_CONSTANTS.MAX_CARD_COPIES,
+    });
   }
 
   const updatedCard = { ...existingCard, count };

--- a/src/domain/deck.ts
+++ b/src/domain/deck.ts
@@ -10,14 +10,14 @@
  * - パフォーマンス最適化のためにMapベースの内部処理を活用
  */
 import { ok, err, type Result } from "neverthrow";
-import { GAME_CONSTANTS } from "../constants/game";
-import type { Card } from "../types/card";
+import { GAME_CONSTANTS } from "../constants";
 import type {
+  Card,
   DeckCard,
   DeckState,
   DeckOperation,
   DeckOperationError,
-} from "../types/deck";
+} from "../types";
 
 // =============================================================================
 // Map ベースのパフォーマンス最適化関数

--- a/src/domain/filter.ts
+++ b/src/domain/filter.ts
@@ -7,8 +7,7 @@
  * - 副作用を避け、不変データ構造を優先する関数型アプローチを採用
  * - エラーハンドリングは不要なため、neverthrowは使用しない
  */
-import type { Card } from "../types/card";
-import type { FilterCondition } from "../types/filter";
+import type { Card, FilterCondition } from "../types";
 import {
   searchCardsByName,
   filterCardsByKind,

--- a/src/domain/sort.ts
+++ b/src/domain/sort.ts
@@ -1,9 +1,5 @@
 import type { Card, DeckCard } from "../types";
-import {
-  createNaturalSort,
-  createKindSort,
-  createTypeSort,
-} from "../utils/sort";
+import { createNaturalSort, createKindSort, createTypeSort } from "../utils";
 
 /**
  * @file カードとデッキカードのソートに関するドメインロジックを定義する。

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,9 +2,15 @@ import { createApp } from "vue";
 import { createPinia } from "pinia";
 import "./style.css";
 import App from "./App.vue";
+import { startImageCacheMaintenance } from "./utils/image";
 
 const pinia = createPinia();
 const app = createApp(App);
 
 app.use(pinia);
 app.mount("#app");
+
+// クライアントサイドでのみ画像キャッシュのメンテナンスを開始
+if (typeof window !== 'undefined') {
+  startImageCacheMaintenance();
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import { createApp } from "vue";
 import { createPinia } from "pinia";
 import "./style.css";
 import App from "./App.vue";
-import { startImageCacheMaintenance } from "./utils/image";
+import { startImageCacheMaintenance, destroyImageCache } from "./utils/image";
 
 const pinia = createPinia();
 const app = createApp(App);
@@ -11,6 +11,12 @@ app.use(pinia);
 app.mount("#app");
 
 // クライアントサイドでのみ画像キャッシュのメンテナンスを開始
-if (typeof window !== 'undefined') {
+if (!import.meta.env.SSR) {
   startImageCacheMaintenance();
+}
+// HMR時にクリーンアップ
+if (import.meta.hot) {
+  import.meta.hot.dispose(() => {
+    destroyImageCache();
+  });
 }

--- a/src/stores/cards.ts
+++ b/src/stores/cards.ts
@@ -330,11 +330,9 @@ export const useCardsStore = defineStore("cards", () => {
       const checkedCards = ensured.value;
       availableCards.value = readonly(checkedCards);
       updateCaches(checkedCards);
-      if (!import.meta.env.SSR) {
-        const preloadResult = preloadImages(checkedCards);
-        if (preloadResult.isErr()) {
-          logger.warn("画像のプリロードに失敗しました:", preloadResult.error);
-        }
+      const preloadResult = preloadImages(checkedCards);
+      if (preloadResult.isErr()) {
+        logger.warn("画像のプリロードに失敗しました:", preloadResult.error);
       }
       logger.info(`${checkedCards.length}枚のカードを読み込みました`);
     } catch (e) {

--- a/src/stores/cards.ts
+++ b/src/stores/cards.ts
@@ -24,7 +24,7 @@ type CardStoreError =
 
 export const useCardsStore = defineStore("cards", () => {
   const availableCards = shallowRef<readonly Card[]>([]);
-  const isLoading = ref<boolean>(true);
+  const isLoading = ref<boolean>(false);
   const error = ref<CardStoreError | null>(null);
 
   // カードデータのバージョン管理（キャッシュ無効化用）

--- a/src/stores/cards.ts
+++ b/src/stores/cards.ts
@@ -330,9 +330,11 @@ export const useCardsStore = defineStore("cards", () => {
       const checkedCards = ensured.value;
       availableCards.value = readonly(checkedCards);
       updateCaches(checkedCards);
-      const preloadResult = preloadImages(checkedCards);
-      if (preloadResult.isErr()) {
-        logger.warn("画像のプリロードに失敗しました:", preloadResult.error);
+      if (!import.meta.env.SSR) {
+        const preloadResult = preloadImages(checkedCards);
+        if (preloadResult.isErr()) {
+          logger.warn("画像のプリロードに失敗しました:", preloadResult.error);
+        }
       }
       logger.info(`${checkedCards.length}枚のカードを読み込みました`);
     } catch (e) {

--- a/src/stores/cards.ts
+++ b/src/stores/cards.ts
@@ -64,7 +64,7 @@ export const useCardsStore = defineStore("cards", () => {
       // HTTP エラー: "HTTP error! status: <code>"
       const statusMatch = errorMessage.match(/^HTTP error! status:\s+(\d+)/);
       if (statusMatch) {
-        const status = statusMatch ? parseInt(statusMatch[1]) : 500;
+        const status = parseInt(statusMatch[1], 10);
         return {
           type: "fetch",
           status,
@@ -73,8 +73,8 @@ export const useCardsStore = defineStore("cards", () => {
       }
       // パース系
       if (
-        errorMessage.includes("CSVデータが空です。") ||
-        errorMessage.includes("CSVパースエラー:")
+        errorMessage.startsWith("CSVデータが空です。") ||
+        errorMessage.startsWith("CSVパースエラー:")
       ) {
         return {
           type: "parse",
@@ -93,7 +93,7 @@ export const useCardsStore = defineStore("cards", () => {
         };
       }
       // ネットワーク系
-      if (errorMessage.includes("ネットワークエラー:")) {
+      if (errorMessage.startsWith("ネットワークエラー:")) {
         return {
           type: "fetch",
           status: 0, // ネットワークエラーはHTTPステータスがないため0
@@ -310,7 +310,9 @@ export const useCardsStore = defineStore("cards", () => {
       if (csvLoadResult.isErr()) {
         const mapped = mapErrorToCardStoreError(csvLoadResult.error);
         error.value = mapped;
-        logger.error("カードデータの読み込みエラー:", mapped);
+        logger.error("カードデータの読み込みエラー:", mapped, {
+          cause: csvLoadResult.error,
+        });
         return;
       }
       const validCards = validateCards(csvLoadResult.value);
@@ -318,7 +320,9 @@ export const useCardsStore = defineStore("cards", () => {
       if (ensured.isErr()) {
         const mapped = mapErrorToCardStoreError(ensured.error);
         error.value = mapped;
-        logger.error("カードデータの読み込みエラー:", mapped);
+        logger.error("カードデータの読み込みエラー:", mapped, {
+          cause: ensured.error,
+        });
         return;
       }
       // 成功パス

--- a/src/stores/cards.ts
+++ b/src/stores/cards.ts
@@ -300,6 +300,7 @@ export const useCardsStore = defineStore("cards", () => {
    * カードデータを読み込む
    */
   const loadCards = async (): Promise<void> => {
+    if (isLoading.value) return; // 再入防止
     isLoading.value = true;
     error.value = null;
 

--- a/src/stores/cards.ts
+++ b/src/stores/cards.ts
@@ -1,12 +1,15 @@
 import { defineStore } from "pinia";
 import { ref, shallowRef, readonly, computed, markRaw, triggerRef } from "vue";
 import type { Card } from "../types";
-import { preloadImages, logger } from "../utils";
-import { safeAsyncOperation } from "../utils/errorHandler";
-import * as CardDomain from "../domain/card";
+import {
+  preloadImages,
+  loadCardsFromCsv,
+  logger,
+  safeAsyncOperation,
+} from "../utils";
+import * as CardDomain from "../domain";
 import { ok, err, type Result } from "neverthrow";
 import { useMemoize } from "@vueuse/core";
-import { loadCardsFromCsv } from "../utils/cardDataConverter";
 
 // カードストア専用のエラー型
 type CardStoreError =

--- a/src/stores/cards.ts
+++ b/src/stores/cards.ts
@@ -1,3 +1,8 @@
+/**
+ * @file カードストア
+ * - 取得/検証/キャッシュ/プリロードのオーケストレーション
+ * - neverthrow Result で例外を外部に漏らさない
+ */
 import { defineStore } from "pinia";
 import { ref, shallowRef, readonly, computed, markRaw, triggerRef } from "vue";
 import type { Card } from "../types";

--- a/src/stores/cards.ts
+++ b/src/stores/cards.ts
@@ -335,6 +335,16 @@ export const useCardsStore = defineStore("cards", () => {
         logger.warn("画像のプリロードに失敗しました:", preloadResult.error);
       }
       logger.info(`${checkedCards.length}枚のカードを読み込みました`);
+    } catch (e) {
+      const mapped = mapErrorToCardStoreError(e);
+      error.value = mapped;
+      logger.error(
+        "カードデータの読み込み中に予期せぬエラーが発生しました:",
+        mapped,
+        {
+          cause: e,
+        },
+      );
     } finally {
       isLoading.value = false;
     }
@@ -363,9 +373,9 @@ export const useCardsStore = defineStore("cards", () => {
 
   return {
     // リアクティブな状態
-    availableCards,
-    isLoading,
-    error,
+    availableCards: readonly(availableCards),
+    isLoading: readonly(isLoading),
+    error: readonly(error),
     cardCount,
     hasCards,
     isReady,

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -220,18 +220,24 @@ export const useDeckStore = defineStore("deck", () => {
     flush: () => void;
     cancel: () => void;
   };
-  const debouncedSave = useDebounceFn(
-    (cards: DeckCard[]) => {
-      saveDeckToLocalStorage(cards);
-    },
+const debouncedSave = useDebounceFn(
+  (cards: DeckCard[]) => {
+    const r = saveDeckToLocalStorage(cards);
+    if (r.isErr()) {
+      errorHandler.handleRuntimeError("デッキの保存に失敗しました", r.error);
+    }
+  },
     500,
     { maxWait: 2000 },
   ) as unknown as FlushableFn<[DeckCard[]]>;
 
-  const debouncedSaveName = useDebounceFn(
-    (name: string) => {
-      saveDeckName(name);
-    },
+const debouncedSaveName = useDebounceFn(
+  (name: string) => {
+    const r = saveDeckName(name);
+    if (r.isErr()) {
+      errorHandler.handleRuntimeError("デッキ名の保存に失敗しました", r.error);
+    }
+  },
     500,
     { maxWait: 2000 },
   ) as unknown as FlushableFn<[string]>;
@@ -257,8 +263,10 @@ export const useDeckStore = defineStore("deck", () => {
     // 念のため後続の遅延保存を打ち切る
     debouncedSave.cancel?.();
     debouncedSaveName.cancel?.();
-    saveDeckToLocalStorage(deckCards.value);
-    saveDeckName(deckName.value);
+  const r1 = saveDeckToLocalStorage(deckCards.value);
+  if (r1.isErr()) errorHandler.handleRuntimeError("デッキの即時保存に失敗しました", r1.error);
+  const r2 = saveDeckName(deckName.value);
+  if (r2.isErr()) errorHandler.handleRuntimeError("デッキ名の即時保存に失敗しました", r2.error);
   };
 
   // ブラウザ環境でのみイベントリスナーを設定

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -7,7 +7,7 @@ import {
   saveDeckName,
   loadDeckName,
   resetDeckCardsInLocalStorage,
-  removeDeckNameFromLocalStorage,
+  resetDeckNameInLocalStorage,
   createVersionedState,
   createArraySortMemo,
   createErrorHandler,
@@ -225,7 +225,7 @@ export const useDeckStore = defineStore("deck", () => {
    */
   const resetDeckName = () => {
     deckName.value = "新しいデッキ";
-    removeDeckNameFromLocalStorage();
+    resetDeckNameInLocalStorage();
   };
 
   /**

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -39,7 +39,8 @@ const generateDeckHash = (deckCards: readonly DeckCard[]): string => {
   // カードIDと枚数のタプル配列をソートし、JSON化して衝突を回避
   const entries = deckCards
     .map((dc) => [dc.card.id, dc.count] as const)
-    .toSorted((a, b) => a[0].localeCompare(b[0]));
+    .slice()
+    .sort((a, b) => a[0].localeCompare(b[0]));
   return JSON.stringify(entries);
 };
 
@@ -229,7 +230,8 @@ export const useDeckStore = defineStore("deck", () => {
    * デッキ名を設定
    */
   const setDeckName = (name: string): void => {
-    const n = name.trim() || DEFAULT_DECK_NAME;
+    const n = name.trim();
+    if (!n) return resetDeckName();
     if (deckName.value === n) return;
     deckName.value = n;
   };

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -211,7 +211,13 @@ export const useDeckStore = defineStore("deck", () => {
    */
   const resetDeckCards = () => {
     updateDeckCardsWithVersion([]);
-    resetDeckCardsInLocalStorage();
+    const r = resetDeckCardsInLocalStorage();
+    if (r.isErr()) {
+      errorHandler.handleRuntimeError(
+        "デッキカードのリセットに失敗しました",
+        r.error,
+      );
+    }
   };
 
   /**

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -260,10 +260,12 @@ export const useDeckStore = defineStore("deck", () => {
   // ページアンロード時の保存保証
   const handleBeforeUnload = () => {
     // 未処理のデバウンスを反映/無効化してから直接保存
-    // @ts-expect-error VueUseの戻り値はflush/cancelを持つ
-    debouncedSave.flush?.();
-    // @ts-expect-error
-    debouncedSaveName.flush?.();
+    type Flushable = { flush?: () => void; cancel?: () => void };
+    (debouncedSave as unknown as Flushable).flush?.();
+    (debouncedSaveName as unknown as Flushable).flush?.();
+    // 念のため後続の遅延保存を打ち切る
+    (debouncedSave as unknown as Flushable).cancel?.();
+    (debouncedSaveName as unknown as Flushable).cancel?.();
     saveDeckToLocalStorage(deckCards.value);
     saveDeckName(deckName.value);
   };

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -188,9 +188,7 @@ export const useDeckStore = defineStore("deck", () => {
   const setDeckCards = (cards: readonly DeckCard[]) => {
     const state = calculateDeckState(cards);
     if (state.type === "invalid") {
-      errorHandler.handleRuntimeError("無効なデッキです", {
-        errors: state.errors,
-      });
+      errorHandler.handleValidationError("無効なデッキです", state.errors);
       return;
     }
     updateDeckCardsWithVersion(cards);

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -6,7 +6,7 @@ import {
   loadDeckFromLocalStorage,
   saveDeckName,
   loadDeckName,
-  removeDeckCardsFromLocalStorage,
+  resetDeckNameInLocalStorage,
   removeDeckNameFromLocalStorage,
   createVersionedState,
   createArraySortMemo,
@@ -211,7 +211,7 @@ export const useDeckStore = defineStore("deck", () => {
    */
   const resetDeckCards = () => {
     updateDeckCardsWithVersion([]);
-    removeDeckCardsFromLocalStorage();
+    resetDeckNameInLocalStorage();
   };
 
   /**

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -1,13 +1,5 @@
 import { defineStore } from "pinia";
-import {
-  ref,
-  computed,
-  watch,
-  readonly,
-  shallowRef,
-  onMounted,
-  onBeforeUnmount,
-} from "vue";
+import { ref, computed, watch, readonly, shallowRef } from "vue";
 import type { Card, DeckCard } from "../types";
 import {
   saveDeckToLocalStorage,
@@ -22,7 +14,7 @@ import {
 import { createErrorHandler } from "../utils/errorHandler";
 import * as DeckDomain from "../domain/deck";
 import { sortDeckCards } from "../domain/sort";
-import { useDebounceFn } from "@vueuse/core";
+import { useDebounceFn, useEventListener } from "@vueuse/core";
 
 /**
  * デッキの軽量ハッシュを生成する純粋関数
@@ -274,15 +266,7 @@ export const useDeckStore = defineStore("deck", () => {
 
   // ブラウザ環境でのみイベントリスナーを設定
   if (typeof window !== "undefined") {
-    onMounted(() => {
-      window.addEventListener("beforeunload", handleBeforeUnload);
-    });
-
-    onBeforeUnmount(() => {
-      window.removeEventListener("beforeunload", handleBeforeUnload);
-      // コンポーネント破棄時にも保存を実行
-      handleBeforeUnload();
-    });
+    useEventListener(window, "beforeunload", handleBeforeUnload);
   }
 
   return {

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -108,7 +108,9 @@ export const useDeckStore = defineStore("deck", () => {
     if (result.isOk()) {
       updateDeckCardsWithVersion(result.value);
     } else {
-      errorHandler.handleValidationError(`${onErrMsg}: ${result.error.type}`);
+      errorHandler.handleValidationError(
+        `${onErrMsg}: ${result.error.type} ${JSON.stringify(result.error)}`,
+      );
     }
   };
 
@@ -183,28 +185,30 @@ export const useDeckStore = defineStore("deck", () => {
    * Vue 3.5最適化: デッキカードをリセット
    */
   const resetDeckCards = () => {
-    updateDeckCardsWithVersion([]);
     const r = resetDeckCardsInLocalStorage();
     if (r.isErr()) {
       errorHandler.handleRuntimeError(
         "デッキカードのリセットに失敗しました",
         r.error,
       );
+      return;
     }
+    updateDeckCardsWithVersion([]);
   };
 
   /**
    * デッキ名をリセット
    */
   const resetDeckName = () => {
-    deckName.value = "新しいデッキ";
     const r = resetDeckNameInLocalStorage();
     if (r.isErr()) {
       errorHandler.handleRuntimeError(
         "デッキ名のリセットに失敗しました",
         r.error,
       );
+      return;
     }
+    deckName.value = "新しいデッキ";
   };
 
   /**
@@ -283,7 +287,9 @@ export const useDeckStore = defineStore("deck", () => {
   // ブラウザ環境でのみイベントリスナーを設定
   if (typeof window !== "undefined") {
     useEventListener(window, "beforeunload", handleBeforeUnload);
-    useEventListener(window, "pagehide", handleBeforeUnload);
+    useEventListener(window, "pagehide", (e: PageTransitionEvent) => {
+      if (!e.persisted) handleBeforeUnload();
+    });
     if (typeof document !== "undefined") {
       useEventListener(document, "visibilitychange", () => {
         if (document.visibilityState === "hidden") handleBeforeUnload();

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -10,10 +10,13 @@ import {
   removeDeckNameFromLocalStorage,
   createVersionedState,
   createArraySortMemo,
+  createErrorHandler,
 } from "../utils";
-import { createErrorHandler } from "../utils/errorHandler";
-import * as DeckDomain from "../domain/deck";
-import { sortDeckCards } from "../domain/sort";
+import {
+  calculateDeckState,
+  executeDeckOperation,
+  sortDeckCards,
+} from "../domain";
 import { useDebounceFn, useEventListener } from "@vueuse/core";
 
 /**
@@ -87,7 +90,7 @@ export const useDeckStore = defineStore("deck", () => {
    * Vue 3.5最適化: デッキの状態情報
    */
   const deckState = computed(() => {
-    return DeckDomain.calculateDeckState(deckCards.value);
+    return calculateDeckState(deckCards.value);
   });
 
   /**
@@ -101,7 +104,7 @@ export const useDeckStore = defineStore("deck", () => {
    * Vue 3.5最適化: カードをデッキに追加
    */
   const addCardToDeck = (card: Card): void => {
-    const result = DeckDomain.executeDeckOperation(deckCards.value, {
+    const result = executeDeckOperation(deckCards.value, {
       type: "addCard",
       card,
     });
@@ -119,7 +122,7 @@ export const useDeckStore = defineStore("deck", () => {
    * Vue 3.5最適化: カード枚数を増やす
    */
   const incrementCardCount = (cardId: string): void => {
-    const result = DeckDomain.executeDeckOperation(deckCards.value, {
+    const result = executeDeckOperation(deckCards.value, {
       type: "incrementCount",
       cardId,
     });
@@ -137,7 +140,7 @@ export const useDeckStore = defineStore("deck", () => {
    * Vue 3.5最適化: カード枚数を減らす
    */
   const decrementCardCount = (cardId: string): void => {
-    const result = DeckDomain.executeDeckOperation(deckCards.value, {
+    const result = executeDeckOperation(deckCards.value, {
       type: "decrementCount",
       cardId,
     });
@@ -155,7 +158,7 @@ export const useDeckStore = defineStore("deck", () => {
    * Vue 3.5最適化: カードをデッキから削除
    */
   const removeCardFromDeck = (cardId: string): void => {
-    const result = DeckDomain.executeDeckOperation(deckCards.value, {
+    const result = executeDeckOperation(deckCards.value, {
       type: "removeCard",
       cardId,
     });

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -220,24 +220,27 @@ export const useDeckStore = defineStore("deck", () => {
     flush: () => void;
     cancel: () => void;
   };
-const debouncedSave = useDebounceFn(
-  (cards: DeckCard[]) => {
-    const r = saveDeckToLocalStorage(cards);
-    if (r.isErr()) {
-      errorHandler.handleRuntimeError("デッキの保存に失敗しました", r.error);
-    }
-  },
+  const debouncedSave = useDebounceFn(
+    (cards: DeckCard[]) => {
+      const r = saveDeckToLocalStorage(cards);
+      if (r.isErr()) {
+        errorHandler.handleRuntimeError("デッキの保存に失敗しました", r.error);
+      }
+    },
     500,
     { maxWait: 2000 },
   ) as unknown as FlushableFn<[DeckCard[]]>;
 
-const debouncedSaveName = useDebounceFn(
-  (name: string) => {
-    const r = saveDeckName(name);
-    if (r.isErr()) {
-      errorHandler.handleRuntimeError("デッキ名の保存に失敗しました", r.error);
-    }
-  },
+  const debouncedSaveName = useDebounceFn(
+    (name: string) => {
+      const r = saveDeckName(name);
+      if (r.isErr()) {
+        errorHandler.handleRuntimeError(
+          "デッキ名の保存に失敗しました",
+          r.error,
+        );
+      }
+    },
     500,
     { maxWait: 2000 },
   ) as unknown as FlushableFn<[string]>;
@@ -263,10 +266,18 @@ const debouncedSaveName = useDebounceFn(
     // 念のため後続の遅延保存を打ち切る
     debouncedSave.cancel?.();
     debouncedSaveName.cancel?.();
-  const r1 = saveDeckToLocalStorage(deckCards.value);
-  if (r1.isErr()) errorHandler.handleRuntimeError("デッキの即時保存に失敗しました", r1.error);
-  const r2 = saveDeckName(deckName.value);
-  if (r2.isErr()) errorHandler.handleRuntimeError("デッキ名の即時保存に失敗しました", r2.error);
+    const r1 = saveDeckToLocalStorage(deckCards.value);
+    if (r1.isErr())
+      errorHandler.handleRuntimeError(
+        "デッキの即時保存に失敗しました",
+        r1.error,
+      );
+    const r2 = saveDeckName(deckName.value);
+    if (r2.isErr())
+      errorHandler.handleRuntimeError(
+        "デッキ名の即時保存に失敗しました",
+        r2.error,
+      );
   };
 
   // ブラウザ環境でのみイベントリスナーを設定

--- a/src/stores/deck.ts
+++ b/src/stores/deck.ts
@@ -160,28 +160,31 @@ export const useDeckStore = defineStore("deck", () => {
   const initializeDeck = (availableCards: readonly Card[]): void => {
     const prev = suppressSave;
     suppressSave = true;
-    const loadDeckResult = loadDeckFromLocalStorage(availableCards);
-    if (loadDeckResult.isErr()) {
-      updateDeckCardsWithVersion([]);
-      errorHandler.handleRuntimeError(
-        "デッキの読み込みに失敗しました",
-        loadDeckResult.error,
-      );
-    } else {
-      updateDeckCardsWithVersion(loadDeckResult.value);
-    }
+    try {
+     const loadDeckResult = loadDeckFromLocalStorage(availableCards);
+     if (loadDeckResult.isErr()) {
+       updateDeckCardsWithVersion([]);
+       errorHandler.handleRuntimeError(
+         "デッキの読み込みに失敗しました",
+         loadDeckResult.error,
+       );
+     } else {
+       updateDeckCardsWithVersion(loadDeckResult.value);
+     }
 
-    const loadNameResult = loadDeckName();
-    if (loadNameResult.isErr()) {
-      deckName.value = DEFAULT_DECK_NAME;
-      errorHandler.handleRuntimeError(
-        "デッキ名の読み込みに失敗しました",
-        loadNameResult.error,
-      );
-    } else {
-      deckName.value = loadNameResult.value;
-    }
-    suppressSave = prev;
+     const loadNameResult = loadDeckName();
+     if (loadNameResult.isErr()) {
+       deckName.value = DEFAULT_DECK_NAME;
+       errorHandler.handleRuntimeError(
+         "デッキ名の読み込みに失敗しました",
+         loadNameResult.error,
+       );
+     } else {
+       deckName.value = loadNameResult.value;
+     }
+   } finally {
+     suppressSave = prev;
+   }
   };
 
   /**
@@ -231,8 +234,13 @@ export const useDeckStore = defineStore("deck", () => {
    */
   const setDeckName = (name: string): void => {
     const n = name.trim();
-    if (!n) return resetDeckName();
-    if (deckName.value === n) return;
+   if (!n) {
+     resetDeckName();
+     return;
+   }
+   if (deckName.value === n) {
+     return;
+   }
     deckName.value = n;
   };
 

--- a/src/stores/deckCode.ts
+++ b/src/stores/deckCode.ts
@@ -10,7 +10,7 @@ import {
 } from "../utils";
 import { GAME_CONSTANTS } from "../constants";
 import { useDeckStore } from "./deck";
-import { sortDeckCards } from "../domain/sort";
+import { sortDeckCards } from "../domain";
 import { useClipboard } from "@vueuse/core";
 
 export const useDeckCodeStore = defineStore("deckCode", () => {

--- a/src/stores/deckCode.ts
+++ b/src/stores/deckCode.ts
@@ -90,7 +90,8 @@ export const useDeckCodeStore = defineStore("deckCode", () => {
    */
   const copyDeckCode = async (codeType: "slash" | "kcg"): Promise<void> => {
     error.value = null;
-    const codeToCopy = codeType === "slash" ? slashDeckCode.value : kcgDeckCode.value;
+    const codeToCopy =
+      codeType === "slash" ? slashDeckCode.value : kcgDeckCode.value;
 
     try {
       await copyToClipboard(codeToCopy);

--- a/src/stores/deckCode.ts
+++ b/src/stores/deckCode.ts
@@ -10,7 +10,6 @@ import {
 } from "../utils";
 import { GAME_CONSTANTS } from "../constants";
 import { useDeckStore } from "./deck";
-
 import { sortDeckCards } from "../domain/sort";
 import { useClipboard } from "@vueuse/core";
 
@@ -24,7 +23,7 @@ export const useDeckCodeStore = defineStore("deckCode", () => {
   const error = ref<DeckCodeError | null>(null);
   const deckStore = useDeckStore();
 
-  const { copy: copyToClipboard } = useClipboard();
+  const { copy: copyToClipboard, isSupported } = useClipboard();
 
   /**
    * デッキコードを生成
@@ -92,6 +91,21 @@ export const useDeckCodeStore = defineStore("deckCode", () => {
     error.value = null;
     const codeToCopy =
       codeType === "slash" ? slashDeckCode.value : kcgDeckCode.value;
+
+    if (!codeToCopy) {
+      const msg = `${codeType === "slash" ? "スラッシュ区切り" : "KCG形式"}デッキコードが空です`;
+      logger.warn(msg);
+      error.value = { type: "copy", message: msg };
+      return;
+    }
+
+    if (!isSupported.value) {
+      const msg =
+        "この環境ではクリップボードへのコピーがサポートされていません";
+      logger.warn(msg);
+      error.value = { type: "copy", message: msg };
+      return;
+    }
 
     try {
       await copyToClipboard(codeToCopy);

--- a/src/stores/export.ts
+++ b/src/stores/export.ts
@@ -84,7 +84,10 @@ export const useExportStore = defineStore("export", () => {
 
       const cleanupListeners = () => {
         for (const stop of stops) stop();
-        if (timeoutId) clearTimeout(timeoutId);
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = undefined;
+        }
         stops.length = 0;
       };
 
@@ -140,6 +143,7 @@ export const useExportStore = defineStore("export", () => {
       };
 
       images.forEach((img) => {
+        if (hasErrorOccurred) return;
         if (img.complete && img.naturalWidth > 0 && img.naturalHeight > 0) {
           // 既に読み込み済みの画像
           checkComplete();

--- a/src/stores/export.ts
+++ b/src/stores/export.ts
@@ -38,7 +38,9 @@ const redactUrl = (src?: string): string => {
   if (!src) return "不明な画像";
   try {
     const base =
-      typeof window !== "undefined" ? window.location.origin : "http://local";
+      typeof window !== "undefined"
+        ? window.location.origin
+        : "http://localhost";
     const u = new URL(src, base);
     if (u.protocol === "blob:") return "(blob)";
     if (u.protocol === "data:") return "(data-uri)";
@@ -195,7 +197,10 @@ export const useExportStore = defineStore("export", () => {
       // Canvas生成 (neverthrow でラップ)
       const canvasResult = await fromPromise(
         html2canvas(exportContainer, {
-          scale: 1,
+          scale:
+            typeof window !== "undefined"
+              ? Math.max(1, window.devicePixelRatio || 1)
+              : 1,
           useCORS: true,
           logging: false,
           allowTaint: false,

--- a/src/stores/export.ts
+++ b/src/stores/export.ts
@@ -51,7 +51,7 @@ export const useExportStore = defineStore("export", () => {
         resolve(
           err({
             type: "imageLoad",
-            message: "画像の読み込みがタイムアウトしました",
+            message: `画像の読み込みがタイムアウトしました (${loadedCount}/${images.length}枚読み込み済み)`,
             originalError: new Error("timeout"),
           }),
         );

--- a/src/stores/export.ts
+++ b/src/stores/export.ts
@@ -1,8 +1,9 @@
 import { defineStore } from "pinia";
-import { ref, nextTick, readonly } from "vue"; // readonly を追加
+import { ref, nextTick, readonly } from "vue";
 import html2canvas from "html2canvas-pro";
 import { generateFileName, downloadCanvas, logger } from "../utils";
-import { ok, err, type Result } from "neverthrow"; // ok, err を追加
+import { ok, err, type Result } from "neverthrow";
+import { useEventListener } from "@vueuse/core";
 
 // エクスポートストア専用のエラー型
 type ExportError =
@@ -43,10 +44,7 @@ export const useExportStore = defineStore("export", () => {
       let hasErrorOccurred = false;
 
       const cleanupListeners = () => {
-        images.forEach((img) => {
-          img.removeEventListener("load", checkComplete);
-          img.removeEventListener("error", handleImageError);
-        });
+        images.forEach;
       };
 
       const checkComplete = () => {
@@ -80,8 +78,8 @@ export const useExportStore = defineStore("export", () => {
           checkComplete();
         } else {
           // まだ読み込み中の画像
-          img.addEventListener("load", checkComplete, { once: true });
-          img.addEventListener("error", handleImageError, { once: true });
+          useEventListener(img, "load", checkComplete, { once: true });
+          useEventListener(img, "error", handleImageError, { once: true });
         }
       });
     });

--- a/src/stores/export.ts
+++ b/src/stores/export.ts
@@ -42,9 +42,10 @@ export const useExportStore = defineStore("export", () => {
 
       let loadedCount = 0;
       let hasErrorOccurred = false;
+      const stops: Array<() => void> = [];
 
       const cleanupListeners = () => {
-        images.forEach;
+        for (const stop of stops) stop();
       };
 
       const checkComplete = () => {
@@ -78,8 +79,13 @@ export const useExportStore = defineStore("export", () => {
           checkComplete();
         } else {
           // まだ読み込み中の画像
-          useEventListener(img, "load", checkComplete, { once: true });
-          useEventListener(img, "error", handleImageError, { once: true });
+          const offLoad = useEventListener(img, "load", checkComplete, {
+            once: true,
+          });
+          const offError = useEventListener(img, "error", handleImageError, {
+            once: true,
+          });
+          stops.push(offLoad, offError);
         }
       });
     });

--- a/src/stores/export.ts
+++ b/src/stores/export.ts
@@ -33,6 +33,8 @@ const redactUrl = (src?: string): string => {
   if (!src) return "不明な画像";
   try {
     const u = new URL(src, window.location.href);
+    if (u.protocol === "blob:") return "(blob)";
+    if (u.protocol === "data:") return "(data-uri)";
     const file = u.pathname.split("/").pop();
     return file || "(image)";
   } catch {
@@ -40,6 +42,7 @@ const redactUrl = (src?: string): string => {
   }
 };
 
+const IMAGE_LOAD_TIMEOUT_MS = 8000;
 export const useExportStore = defineStore("export", () => {
   const isSaving = ref<boolean>(false);
 
@@ -61,7 +64,6 @@ export const useExportStore = defineStore("export", () => {
       let hasErrorOccurred = false;
       const stops: Array<() => void> = [];
 
-      const IMAGE_LOAD_TIMEOUT_MS = 8000;
       const timeoutId = window.setTimeout(() => {
         if (hasErrorOccurred) return;
         hasErrorOccurred = true;

--- a/src/stores/export.ts
+++ b/src/stores/export.ts
@@ -44,9 +44,9 @@ const redactUrl = (src?: string): string => {
     const u = new URL(src, base);
     if (u.protocol === "blob:") return "(blob)";
     if (u.protocol === "data:") return "(data-uri)";
-  if (u.protocol !== "http:" && u.protocol !== "https:") {
-    return `(${u.protocol.replace(":", "")})`;
-  }
+    if (u.protocol !== "http:" && u.protocol !== "https:") {
+      return `(${u.protocol.replace(":", "")})`;
+    }
     const file = u.pathname.split("/").pop();
     return file || "(image)";
   } catch {

--- a/src/stores/export.ts
+++ b/src/stores/export.ts
@@ -44,8 +44,22 @@ export const useExportStore = defineStore("export", () => {
       let hasErrorOccurred = false;
       const stops: Array<() => void> = [];
 
+      const timeoutId = window.setTimeout(() => {
+        if (hasErrorOccurred) return;
+        hasErrorOccurred = true;
+        cleanupListeners();
+        resolve(
+          err({
+            type: "imageLoad",
+            message: "画像の読み込みがタイムアウトしました",
+            originalError: new Error("timeout"),
+          }),
+        );
+      }, 8000);
+
       const cleanupListeners = () => {
         for (const stop of stops) stop();
+        clearTimeout(timeoutId);
       };
 
       const checkComplete = () => {

--- a/src/stores/filter.ts
+++ b/src/stores/filter.ts
@@ -7,12 +7,10 @@ import {
   triggerRef,
   type ComputedRef,
 } from "vue";
-import type { Card, FilterCriteria } from "../types";
-import type { CardKind, CardType } from "../types/card";
-import { CARD_KINDS, CARD_TYPES, PRIORITY_TAGS } from "../constants/game";
-import * as CardDomain from "../domain/card";
+import type { Card, CardKind, CardType, FilterCriteria } from "../types";
+import { CARD_KINDS, CARD_TYPES, PRIORITY_TAGS } from "../constants";
 import { useCardsStore } from "./cards";
-import { sortCards } from "../domain/sort";
+import { searchCardsByName, sortCards } from "../domain";
 import {
   createArraySortMemo,
   createFilterMemo,
@@ -150,7 +148,7 @@ export const useFilterStore = defineStore("filter", () => {
       return cards;
     }
 
-    return CardDomain.searchCardsByName(cards, normalizedText);
+    return searchCardsByName(cards, normalizedText);
   };
 
   /**

--- a/src/stores/filter.ts
+++ b/src/stores/filter.ts
@@ -1,12 +1,8 @@
+/**
+ * [spec] フィルタ条件の状態管理（Pinia）。カード一覧の抽出/並び替え/統計を提供するストア。
+ */
 import { defineStore } from "pinia";
-import {
-  ref,
-  readonly,
-  computed,
-  shallowRef,
-  triggerRef,
-  type ComputedRef,
-} from "vue";
+import { ref, readonly, computed, shallowRef, type ComputedRef } from "vue";
 import type { Card, CardKind, CardType, FilterCriteria } from "../types";
 import { CARD_KINDS, CARD_TYPES, PRIORITY_TAGS } from "../constants";
 import { useCardsStore } from "./cards";
@@ -388,7 +384,6 @@ export const useFilterStore = defineStore("filter", () => {
    */
   const updateFilterCriteria = (criteria: FilterCriteria): void => {
     filterCriteria.value = { ...criteria };
-    triggerRef(filterCriteria); // 手動でリアクティブ更新をトリガー
   };
 
   /**
@@ -490,8 +485,8 @@ export const useFilterStore = defineStore("filter", () => {
     filterStats,
 
     // 定数
-    allKinds: readonly([...CARD_KINDS]),
-    allTypes: readonly([...CARD_TYPES]),
+    allKinds: CARD_KINDS,
+    allTypes: CARD_TYPES,
 
     // アクション
     openFilterModal,

--- a/src/stores/filter.ts
+++ b/src/stores/filter.ts
@@ -143,12 +143,7 @@ export const useFilterStore = defineStore("filter", () => {
       return cards;
     }
 
-    const normalizedText = text.trim().toLowerCase();
-    if (normalizedText.length === 0) {
-      return cards;
-    }
-
-    return searchCardsByName(cards, normalizedText);
+    return searchCardsByName(cards, text);
   };
 
   /**

--- a/src/utils/cardDataConverter.ts
+++ b/src/utils/cardDataConverter.ts
@@ -105,7 +105,8 @@ function isCardType(value: string): value is CardType {
 export async function loadCardsFromCsv(
   csvPath: string,
 ): Promise<Result<Card[], Error>> {
-  if (import.meta.env?.DEV) logger.debug("Attempting to fetch CSV from:", csvPath);
+  if (import.meta.env?.DEV)
+    logger.debug("Attempting to fetch CSV from:", csvPath);
 
   try {
     // 通常のfetch APIを使用（useFetchの代わり）
@@ -131,7 +132,8 @@ export async function loadCardsFromCsv(
       return err(new Error("CSVデータが空です。"));
     }
 
-    if (import.meta.env?.DEV) logger.debug("CSV data fetched successfully, length:", csvText.length);
+    if (import.meta.env?.DEV)
+      logger.debug("CSV data fetched successfully, length:", csvText.length);
 
     // papaparse を使用してCSVをパース
     const parseResult = parseCsv(csvText);
@@ -214,6 +216,7 @@ function parseCsv(csvText: string): Result<Card[], Error> {
     });
   }
 
-  if (import.meta.env?.DEV) logger.debug("Successfully parsed cards:", cards.length);
+  if (import.meta.env?.DEV)
+    logger.debug("Successfully parsed cards:", cards.length);
   return ok(cards);
 }

--- a/src/utils/cardDataConverter.ts
+++ b/src/utils/cardDataConverter.ts
@@ -139,7 +139,7 @@ export async function loadCardsFromCsv(
     const parseResult = parseCsv(csvText);
     return parseResult;
   } catch (error) {
-    console.error("Fetch error:", error); // デバッグログ
+    logger.error("Fetch error:", error); // デバッグログ
     return err(
       new Error(
         `ネットワークエラー: ${error instanceof Error ? error.message : String(error)}`,
@@ -149,7 +149,7 @@ export async function loadCardsFromCsv(
 }
 
 function parseCsv(csvText: string): Result<Card[], Error> {
-  if (import.meta.env?.DEV) console.debug("Parsing CSV text with PapaParse...");
+  if (import.meta.env?.DEV) logger.debug("Parsing CSV text with PapaParse...");
   const parseResult = Papa.parse<CsvCardRow>(csvText, {
     header: true, // ヘッダー行をオブジェクトのキーとして使用
     skipEmptyLines: true, // 空行をスキップ
@@ -166,7 +166,7 @@ function parseCsv(csvText: string): Result<Card[], Error> {
   });
 
   if (parseResult.errors.length > 0) {
-    console.error("PapaParse errors:", parseResult.errors);
+    logger.error("PapaParse errors:", parseResult.errors);
     return err(new Error(`CSVパースエラー: ${parseResult.errors[0].message}`));
   }
 

--- a/src/utils/cardDataConverter.ts
+++ b/src/utils/cardDataConverter.ts
@@ -8,7 +8,7 @@
 import type { Card, CardKind, CardType } from "../types";
 import { CARD_KINDS, CARD_TYPES } from "../constants";
 import { type Result, ok, err } from "neverthrow";
-import { logger } from "../utils";
+import { logger } from "./logger";
 import Papa from "papaparse";
 
 interface CsvCardRow {

--- a/src/utils/cardDataConverter.ts
+++ b/src/utils/cardDataConverter.ts
@@ -5,8 +5,8 @@
  *        neverthrow Result型を使用して、成功または失敗の結果を明示的に扱います。
  */
 
-import type { Card, CardKind, CardType } from "../types/card";
-import { CARD_KINDS, CARD_TYPES } from "../constants/game";
+import type { Card, CardKind, CardType } from "../types";
+import { CARD_KINDS, CARD_TYPES } from "../constants";
 import { type Result, ok, err } from "neverthrow";
 import { logger } from "../utils";
 import Papa from "papaparse";

--- a/src/utils/deckCode.ts
+++ b/src/utils/deckCode.ts
@@ -9,10 +9,9 @@
  * - neverthrowのResult型を使用してエラーを表現
  * - 例外をスローせず、エラーの詳細を型安全に返却
  */
-import type { Card } from "../types/card";
-import type { DeckCard } from "../types/deck";
-import { logger } from "./logger"; // loggerをインポート
-import { ok, err, type Result } from "neverthrow"; // Result をインポート
+import type { Card, DeckCard } from "../types";
+import { logger } from "./logger";
+import { ok, err, type Result } from "neverthrow";
 
 // --- KCGデッキコード用定数（IDHolder.csの定数に対応） ---
 const CHAR_MAP =

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -1,4 +1,4 @@
-import type { Card, CardType } from "../types/card";
+import type { Card, CardType } from "../types";
 
 /**
  * カードがテキスト検索にマッチするかチェック

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -1,3 +1,7 @@
+/**
+ * フィルタユーティリティ
+ * - テキスト/タイプ/タグ一致判定の純粋関数群（副作用なし）
+ */
 import type { Card, CardType } from "../types";
 
 /**
@@ -40,11 +44,7 @@ export const isCardMatchingTag = (card: Card, tagSet: Set<string>): boolean => {
   }
 
   if (Array.isArray(card.tags)) {
-    // タグが配列の場合
-    return card.tags.some((tag: string) => tagSet.has(tag));
-  } else if (typeof card.tags === "string") {
-    // タグが文字列の場合
-    return tagSet.has(card.tags);
+    return card.tags.some((tag) => tagSet.has(tag));
   }
 
   return false;

--- a/src/utils/filter.ts
+++ b/src/utils/filter.ts
@@ -16,10 +16,9 @@ export const isCardMatchingText = (card: Card, textLower: string): boolean => {
     return true;
   }
 
-  // タグでの検索
-  if (card.tags) {
-    const tags = Array.isArray(card.tags) ? card.tags : [card.tags];
-    return tags.some((tag: string) => tag.toLowerCase().includes(textLower));
+  // タグでの検索（tags は配列前提）
+  if (Array.isArray(card.tags)) {
+    return card.tags.some((tag) => tag.toLowerCase().includes(textLower));
   }
 
   return false;

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -264,11 +264,11 @@ export const preloadImages = (cards: readonly Card[]): Result<void, string> => {
       const card = cards[currentIndex];
 
       if (!hasCacheEntry(card.id) && !cacheState.inflight.has(card.id)) {
-        cacheState.inflight.add(card.id);
-        const img = new Image();
-        img.crossOrigin = "anonymous";
         const urlResult = getCardImageUrl(card.id);
         if (urlResult.isOk()) {
+          cacheState.inflight.add(card.id);
+          const img = new Image();
+          img.crossOrigin = "anonymous";
           img.onload = () => {
             setCacheEntry(card.id, img);
             cacheState.inflight.delete(card.id);
@@ -282,6 +282,11 @@ export const preloadImages = (cards: readonly Card[]): Result<void, string> => {
             img.onerror = null;
           };
           img.src = urlResult.value;
+        } else {
+          logger.warn(
+            `Preload skipped: invalid URL for card: ${card.id}`,
+            urlResult.error
+          );
         }
       }
       currentIndex++;

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -260,7 +260,8 @@ export const handleImageError = (event: Event): Result<void, string> => {
   // サポート環境では低優先度での再取得を明示
   try {
     // @ts-ignore - 実装環境によっては存在しない
-    target.fetchPriority = "low";
+    img.fetchPriority = "low";
+    img.decoding = "async";
   } catch {}
   img.src = `${getNormalizedBaseUrl()}placeholder.avif`;
 
@@ -283,7 +284,7 @@ export const preloadImages = (cards: readonly Card[]): Result<void, string> => {
     return ok(undefined);
   }
   // 有効なら低優先度で取得
-  const setLowFetchPriority = (img: HTMLImageElement) => {
+  const setLowFetchPriority = (img: HTMLImageElement): void => {
     try {
       // @ts-ignore
       img.fetchPriority = "low";

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -229,6 +229,7 @@ export const preloadImages = (cards: readonly Card[]): Result<void, string> => {
 
       if (!hasCacheEntry(card.id)) {
         const img = new Image();
+        img.crossOrigin = "anonymous";
         const urlResult = getCardImageUrl(card.id);
         if (urlResult.isOk()) {
           img.src = urlResult.value;

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -1,5 +1,5 @@
 import { ok, err, type Result } from "neverthrow";
-import type { Card } from "../types/card";
+import type { Card } from "../types";
 import { logger } from "./logger";
 
 // LRUキャッシュの設定

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -172,9 +172,10 @@ export const getCardImageUrl = (cardId: string): Result<string, string> => {
     return err("カードIDが指定されていません");
   }
 
-  return ok(
-    `${import.meta.env.BASE_URL}cards/${encodeURIComponent(cardId)}.avif`,
-  );
+  const base = import.meta.env.BASE_URL.endsWith("/")
+    ? import.meta.env.BASE_URL
+    : `${import.meta.env.BASE_URL}/`;
+  return ok(`${base}cards/${encodeURIComponent(cardId)}.avif`);
 };
 
 /**

--- a/src/utils/image.ts
+++ b/src/utils/image.ts
@@ -89,9 +89,14 @@ const hasCacheEntry = (key: string): boolean => {
   if (!key) {
     return false;
   }
-  const exists = cacheState.cache.has(key);
-  if (exists) touchCacheKey(key);
-  return exists;
+  return cacheState.cache.has(key);
+};
+
+export const getCachedImage = (key: string): HTMLImageElement | undefined => {
+  const entry = cacheState.cache.get(key);
+  if (!entry) return undefined;
+  touchCacheKey(key);
+  return entry.image;
 };
 
 /**
@@ -106,6 +111,11 @@ const evictIfNecessary = (): void => {
     cacheState.cache.delete(oldestKey);
   }
 };
+
+const getNormalizedBaseUrl = (): string =>
+  import.meta.env.BASE_URL.endsWith("/")
+    ? import.meta.env.BASE_URL
+    : `${import.meta.env.BASE_URL}/`;
 
 /**
  * 古いエントリーをクリーンアップ
@@ -172,10 +182,7 @@ export const getCardImageUrl = (cardId: string): Result<string, string> => {
     return err("カードIDが指定されていません");
   }
 
-  const base = import.meta.env.BASE_URL.endsWith("/")
-    ? import.meta.env.BASE_URL
-    : `${import.meta.env.BASE_URL}/`;
-  return ok(`${base}cards/${encodeURIComponent(cardId)}.avif`);
+  return ok(`${getNormalizedBaseUrl()}cards/${encodeURIComponent(cardId)}.avif`);
 };
 
 /**
@@ -188,7 +195,7 @@ export const getCardImageUrlSafe = (cardId: string): string => {
   }
   // エラーをログに記録
   logger.warn(`Failed to get image URL for card: ${cardId}`, result.error);
-  return `${import.meta.env.BASE_URL}placeholder.avif`; // エラー時はプレースホルダー画像を返す
+  return `${getNormalizedBaseUrl()}placeholder.avif`;
 };
 
 /**
@@ -204,7 +211,7 @@ export const handleImageError = (event: Event): Result<void, string> => {
     return err("イベントターゲットが画像要素ではありません");
   }
 
-  target.src = `${import.meta.env.BASE_URL}placeholder.avif`;
+  target.src = `${getNormalizedBaseUrl()}placeholder.avif`;
   target.onerror = null;
 
   return ok(undefined);

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from "./cache";
+export * from "./cardDataConverter";
 export * from "./deckCode";
 export * from "./errorHandler";
 export * from "./export";

--- a/src/utils/sort.ts
+++ b/src/utils/sort.ts
@@ -3,8 +3,8 @@
  * - 自然順/種別/タイプの比較関数と合成/反転ヘルパー群
  * - 純粋関数のみ（副作用なし）
  */
-import type { Card, CardType } from "../types/card";
-import { CARD_KINDS, CARD_TYPES } from "../constants/game";
+import type { Card, CardType } from "../types";
+import { CARD_KINDS, CARD_TYPES } from "../constants";
 
 // ソート用の型定義
 export type SortComparator<T> = (a: T, b: T) => number;

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,7 +1,6 @@
 import { ok, err, type Result } from "neverthrow";
-import type { Card } from "../types/card";
-import type { DeckCard } from "../types/deck";
-import { STORAGE_KEYS } from "../constants/storage";
+import type { Card, DeckCard } from "../types";
+import { STORAGE_KEYS } from "../constants";
 import { logger } from "./logger";
 import { useLocalStorage } from "@vueuse/core";
 

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -14,7 +14,7 @@ export type StorageError =
   | { readonly type: "notFound"; readonly key: string }
   | { readonly type: "parseError"; readonly key: string; readonly data: string }
   | { readonly type: "saveError"; readonly key: string; readonly data: unknown }
-  | { readonly type: "removeError"; readonly key: string }
+  | { readonly type: "resetError"; readonly key: string }
   | {
       readonly type: "invalidData";
       readonly key: string;
@@ -212,7 +212,7 @@ export const resetDeckCardsInLocalStorage = (): Result<void, StorageError> => {
     return ok(undefined);
   } catch (e) {
     logger.error("デッキカードのリセットに失敗しました", e, []);
-    return err({ type: "removeError", key: STORAGE_KEYS.DECK_CARDS });
+    return err({ type: "resetError", key: STORAGE_KEYS.DECK_CARDS });
   }
 };
 
@@ -225,6 +225,6 @@ export const resetDeckNameInLocalStorage = (): Result<void, StorageError> => {
     return ok(undefined);
   } catch (e) {
     logger.error("デッキ名のリセットに失敗しました", e, "新しいデッキ");
-    return err({ type: "removeError", key: STORAGE_KEYS.DECK_NAME });
+    return err({ type: "resetError", key: STORAGE_KEYS.DECK_NAME });
   }
 };

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -16,7 +16,11 @@ export type StorageError =
   | { readonly type: "notFound"; readonly key: string }
   | { readonly type: "saveError"; readonly key: string; readonly data: unknown }
   | { readonly type: "resetError"; readonly key: string }
-  | { readonly type: "readError"; readonly key: string; readonly data?: unknown }
+  | {
+      readonly type: "readError";
+      readonly key: string;
+      readonly data?: unknown;
+    }
   | {
       readonly type: "invalidData";
       readonly key: string;
@@ -85,7 +89,8 @@ const deckCardsStorage = useLocalStorage<
               x &&
               typeof x === "object" &&
               typeof (x as any).id === "string" &&
-              Number.isInteger((x as any).count) && (x as any).count >= 0,
+              Number.isInteger((x as any).count) &&
+              (x as any).count >= 0,
           );
         if (isValidArray) {
           return data as { id: string; count: number }[];

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -9,7 +9,7 @@ import { GAME_CONSTANTS, STORAGE_KEYS } from "../constants";
 import { logger } from "./logger";
 import { useLocalStorage } from "@vueuse/core";
 
-const DEFAULT_DECK_NAME = "新しいデッキ" as const;
+export const DEFAULT_DECK_NAME = "新しいデッキ" as const;
 
 // ストレージ操作エラー型
 export type StorageError =
@@ -246,7 +246,7 @@ export const resetDeckCardsInLocalStorage = (): Result<void, StorageError> => {
 };
 
 /**
- * デッキ名をローカルストレージの既定値（"新しいデッキ"）にリセット
+ * デッキ名をローカルストレージの既定値にリセット
  */
 export const resetDeckNameInLocalStorage = (): Result<void, StorageError> => {
   try {

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -120,7 +120,7 @@ export const loadDeckFromLocalStorage = (
       JSON.stringify(deckCardsStorage.value),
     );
     // エラー時はデッキカードのみクリーンアップ（デッキ名は保持）
-    resetDeckNameInLocalStorage();
+    resetDeckCardsInLocalStorage();
     return err({
       type: "parseError",
       key: STORAGE_KEYS.DECK_CARDS,
@@ -166,7 +166,7 @@ export const loadDeckName = (): Result<string, StorageError> => {
 /**
  * デッキ名をローカルストレージで既定値にリセット
  */
-export const resetDeckNameInLocalStorage = (): Result<void, StorageError> => {
+export const resetDeckCardsInLocalStorage = (): Result<void, StorageError> => {
   try {
     deckCardsStorage.value = [];
     return ok(undefined);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

• 新機能
  • 画像キャッシュの定期メンテナンス開始/停止およびキャッシュ操作・統計APIを追加
  • デッキ初期化（初期カード読み込み）を公開APIとして追加
  • PNG出力に同時実行制御（排他）を追加

• 改善
  • 画像モーダルのスワイプ操作安定化と cross-origin 対応
  • モーダル表示中のスクロールロックと ESC キャンセルの信頼性向上
  • 画像読み込みの待機・タイムアウト・破損検出、URLの伏せ字化を強化
  • CSV 解析・検証強化とクリップボード互換性チェック
  • デッキ上限表示・制約を定数化して UI に反映

• 雑務
  • 依存関係を更新（@vueuse/core / @vueuse/integrations → ^13.8.0）
<!-- end of auto-generated comment: release notes by coderabbit.ai -->