### PR TITLE
ex/prmで始まるカードIDを末尾にソート

### DIFF
--- a/src/domain/sort.ts
+++ b/src/domain/sort.ts
@@ -64,8 +64,11 @@ const naturalSort = createNaturalSort();
 const kindSort = createKindSort();
 const typeSort = createTypeSort();
 
+// ex/prm で始まるID検出用（大文字小文字無視）
+const EX_PRM_ID_RE = /^(?:ex|prm)/i;
+
 /**
- * カードの標準比較関数（種類 → タイプ → IDの順）
+ * カードの標準比較関数（種類 → タイプ → ex/prm 末尾ルール → IDの順）
  */
 export const compareCards = (a: Card, b: Card): number => {
   // 実際のカードデータ形式に対応した比較
@@ -78,17 +81,16 @@ export const compareCards = (a: Card, b: Card): number => {
   if (typeComparison !== 0) return typeComparison;
 
   // ex/prm で始まるIDは末尾へ
-  const isExOrPrm = (id: string): boolean => /^(ex|prm)/i.test(id);
-  const aExPrm = isExOrPrm(a.id);
-  const bExPrm = isExOrPrm(b.id);
+  const aExPrm = EX_PRM_ID_RE.test(a.id);
+  const bExPrm = EX_PRM_ID_RE.test(b.id);
   if (aExPrm !== bExPrm) return aExPrm ? 1 : -1;
 
-  // IDで比較（自然順ソート）
+  // IDで比較（ex/prm 末尾ルール適用後、自然順ソート）
   return naturalSort(a.id, b.id);
 };
 
 /**
- * デッキカードの標準比較関数（種類 → タイプ → IDの順）
+ * デッキカードの標準比較関数
  */
 export const compareDeckCards = (a: DeckCard, b: DeckCard): number => {
   return compareCards(a.card, b.card);

--- a/src/domain/sort.ts
+++ b/src/domain/sort.ts
@@ -77,6 +77,12 @@ export const compareCards = (a: Card, b: Card): number => {
   const typeComparison = typeSort({ type: a.type }, { type: b.type });
   if (typeComparison !== 0) return typeComparison;
 
+  // ex/prm で始まるIDは末尾へ
+  const isExOrPrm = (id: string): boolean => /^(ex|prm)/i.test(id);
+  const aExPrm = isExOrPrm(a.id);
+  const bExPrm = isExOrPrm(b.id);
+  if (aExPrm !== bExPrm) return aExPrm ? 1 : -1;
+
   // IDで比較（自然順ソート）
   return naturalSort(a.id, b.id);
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 新機能
  - ID並び替えを拡張し、先頭が「ex」または「prm」（大文字小文字不問）のIDを他のIDより後方に配置するよう変更。
  - 上記条件に該当しないID同士や同条件同士では従来どおりナチュラルソートで並び替え。
  - 一覧や検索結果の表示順が一貫し、意図しない先頭表示を回避。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->